### PR TITLE
improvement: add fhir api definition

### DIFF
--- a/api/fhir.yml
+++ b/api/fhir.yml
@@ -12167,8 +12167,8 @@ services:
           parameters:
             resourceType: string
           docs: Create Resource
-          response: ResourceList
           request: ResourceList
+          response: ResourceList
           errors: []
         readResource:
           method: GET
@@ -12186,8 +12186,8 @@ services:
             resourceType: string
             id: string
           docs: Update Resource
-          response: ResourceList
           request: ResourceList
+          response: ResourceList
           errors: []
         deleteResource:
           method: DELETE

--- a/api/fhir.yml
+++ b/api/fhir.yml
@@ -1,0 +1,12218 @@
+types:
+  ResourceList:
+    union:
+      discriminant: resourceType
+      account: Account
+      activityDefinition: ActivityDefinition
+      adverseEvent: AdverseEvent
+      allergyIntolerance: AllergyIntolerance
+      appointment: Appointment
+      appointmentResponse: AppointmentResponse
+      auditEvent: AuditEvent
+      basic: Basic
+      binary: Binary
+      biologicallyDerivedProduct: BiologicallyDerivedProduct
+      bodyStructure: BodyStructure
+      bundle: Bundle
+      capabilityStatement: CapabilityStatement
+      carePlan: CarePlan
+      careTeam: CareTeam
+      catalogEntry: CatalogEntry
+      chargeItem: ChargeItem
+      chargeItemDefinition: ChargeItemDefinition
+      claim: Claim
+      claimResponse: ClaimResponse
+      clinicalImpression: ClinicalImpression
+      codeSystem: CodeSystem
+      communication: Communication
+      communicationRequest: CommunicationRequest
+      compartmentDefinition: CompartmentDefinition
+      composition: Composition
+      conceptMap: ConceptMap
+      condition: Condition
+      consent: Consent
+      contract: Contract
+      coverage: Coverage
+      coverageEligibilityRequest: CoverageEligibilityRequest
+      coverageEligibilityResponse: CoverageEligibilityResponse
+      detectedIssue: DetectedIssue
+      device: Device
+      deviceDefinition: DeviceDefinition
+      deviceMetric: DeviceMetric
+      deviceRequest: DeviceRequest
+      deviceUseStatement: DeviceUseStatement
+      diagnosticReport: DiagnosticReport
+      documentManifest: DocumentManifest
+      documentReference: DocumentReference
+      effectEvidenceSynthesis: EffectEvidenceSynthesis
+      encounter: Encounter
+      endpoint: Endpoint
+      enrollmentRequest: EnrollmentRequest
+      enrollmentResponse: EnrollmentResponse
+      episodeOfCare: EpisodeOfCare
+      eventDefinition: EventDefinition
+      evidence: Evidence
+      evidenceVariable: EvidenceVariable
+      exampleScenario: ExampleScenario
+      explanationOfBenefit: ExplanationOfBenefit
+      familyMemberHistory: FamilyMemberHistory
+      flag: Flag
+      goal: Goal
+      graphDefinition: GraphDefinition
+      group: Group
+      guidanceResponse: GuidanceResponse
+      healthcareService: HealthcareService
+      imagingStudy: ImagingStudy
+      immunization: Immunization
+      immunizationEvaluation: ImmunizationEvaluation
+      immunizationRecommendation: ImmunizationRecommendation
+      implementationGuide: ImplementationGuide
+      insurancePlan: InsurancePlan
+      invoice: Invoice
+      library: Library
+      linkage: Linkage
+      list: List
+      location: Location
+      measure: Measure
+      measureReport: MeasureReport
+      media: Media
+      medication: Medication
+      medicationAdministration: MedicationAdministration
+      medicationDispense: MedicationDispense
+      medicationKnowledge: MedicationKnowledge
+      medicationRequest: MedicationRequest
+      medicationStatement: MedicationStatement
+      medicinalProduct: MedicinalProduct
+      medicinalProductAuthorization: MedicinalProductAuthorization
+      medicinalProductContraindication: MedicinalProductContraindication
+      medicinalProductIndication: MedicinalProductIndication
+      medicinalProductIngredient: MedicinalProductIngredient
+      medicinalProductInteraction: MedicinalProductInteraction
+      medicinalProductManufactured: MedicinalProductManufactured
+      medicinalProductPackaged: MedicinalProductPackaged
+      medicinalProductPharmaceutical: MedicinalProductPharmaceutical
+      medicinalProductUndesirableEffect: MedicinalProductUndesirableEffect
+      messageDefinition: MessageDefinition
+      messageHeader: MessageHeader
+      molecularSequence: MolecularSequence
+      namingSystem: NamingSystem
+      nutritionOrder: NutritionOrder
+      observation: Observation
+      observationDefinition: ObservationDefinition
+      operationDefinition: OperationDefinition
+      operationOutcome: OperationOutcome
+      organization: Organization
+      organizationAffiliation: OrganizationAffiliation
+      parameters: Parameters
+      patient: Patient
+      paymentNotice: PaymentNotice
+      paymentReconciliation: PaymentReconciliation
+      person: Person
+      planDefinition: PlanDefinition
+      practitioner: Practitioner
+      practitionerRole: PractitionerRole
+      procedure: Procedure
+      provenance: Provenance
+      questionnaire: Questionnaire
+      questionnaireResponse: QuestionnaireResponse
+      relatedPerson: RelatedPerson
+      requestGroup: RequestGroup
+      researchDefinition: ResearchDefinition
+      researchElementDefinition: ResearchElementDefinition
+      researchStudy: ResearchStudy
+      researchSubject: ResearchSubject
+      riskAssessment: RiskAssessment
+      riskEvidenceSynthesis: RiskEvidenceSynthesis
+      schedule: Schedule
+      searchParameter: SearchParameter
+      serviceRequest: ServiceRequest
+      slot: Slot
+      specimen: Specimen
+      specimenDefinition: SpecimenDefinition
+      structureDefinition: StructureDefinition
+      structureMap: StructureMap
+      subscription: Subscription
+      substance: Substance
+      substanceNucleicAcid: SubstanceNucleicAcid
+      substancePolymer: SubstancePolymer
+      substanceProtein: SubstanceProtein
+      substanceReferenceInformation: SubstanceReferenceInformation
+      substanceSourceMaterial: SubstanceSourceMaterial
+      substanceSpecification: SubstanceSpecification
+      supplyDelivery: SupplyDelivery
+      supplyRequest: SupplyRequest
+      task: Task
+      terminologyCapabilities: TerminologyCapabilities
+      testReport: TestReport
+      testScript: TestScript
+      valueSet: ValueSet
+      verificationResult: VerificationResult
+      visionPrescription: VisionPrescription
+      project: Project
+      clientApplication: ClientApplication
+      user: User
+      login: Login
+      refreshToken: RefreshToken
+      passwordChangeRequest: PasswordChangeRequest
+      jsonWebKey: JsonWebKey
+      bot: Bot
+      accessPolicy: AccessPolicy
+      userConfiguration: UserConfiguration
+  base64Binary: string
+  canonical: string
+  code: string
+  date: string
+  dateTime: string
+  decimal: double
+  id: string
+  instant: string
+  markdown: string
+  oid: string
+  positiveInt: integer
+  time: string
+  unsignedInt: integer
+  uri: string
+  url: string
+  uuid: string
+  Element:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+  Extension:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      url: optional<uri>
+      valueBase64Binary: optional<string>
+      valueBoolean: optional<boolean>
+      valueCanonical: optional<string>
+      valueCode: optional<string>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+      valueId: optional<string>
+      valueInstant: optional<string>
+      valueInteger: optional<double>
+      valueMarkdown: optional<string>
+      valueOid: optional<string>
+      valuePositiveInt: optional<double>
+      valueString: optional<string>
+      valueTime: optional<string>
+      valueUnsignedInt: optional<double>
+      valueUri: optional<string>
+      valueUrl: optional<string>
+      valueUuid: optional<string>
+      valueAddress: optional<Address>
+      valueAge: optional<Age>
+      valueAnnotation: optional<Annotation>
+      valueAttachment: optional<Attachment>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueCoding: optional<Coding>
+      valueContactPoint: optional<ContactPoint>
+      valueCount: optional<Count>
+      valueDistance: optional<Distance>
+      valueDuration: optional<Duration>
+      valueHumanName: optional<HumanName>
+      valueIdentifier: optional<Identifier>
+      valueMoney: optional<Money>
+      valuePeriod: optional<Period>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueReference: optional<Reference>
+      valueSampledData: optional<SampledData>
+      valueSignature: optional<Signature>
+      valueTiming: optional<Timing>
+      valueContactDetail: optional<ContactDetail>
+      valueContributor: optional<Contributor>
+      valueDataRequirement: optional<DataRequirement>
+      valueExpression: optional<Expression>
+      valueParameterDefinition: optional<ParameterDefinition>
+      valueRelatedArtifact: optional<RelatedArtifact>
+      valueTriggerDefinition: optional<TriggerDefinition>
+      valueUsageContext: optional<UsageContext>
+      valueDosage: optional<Dosage>
+      valueMeta: optional<Meta>
+  NarrativeStatus:
+    enum:
+      - generated
+      - extensions
+      - additional
+      - empty
+  Narrative:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      status: optional<NarrativeStatus>
+      div: xhtml
+  Annotation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      authorReference: optional<Reference>
+      authorString: optional<string>
+      time: optional<dateTime>
+      text: optional<markdown>
+  Attachment:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      contentType: optional<code>
+      language: optional<code>
+      data: optional<base64Binary>
+      url: optional<url>
+      size: optional<unsignedInt>
+      hash: optional<base64Binary>
+      title: optional<string>
+      creation: optional<dateTime>
+  IdentifierUse:
+    enum:
+      - usual
+      - official
+      - temp
+      - secondary
+      - old
+  Identifier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      use: optional<IdentifierUse>
+      type: optional<CodeableConcept>
+      system: optional<uri>
+      value: optional<string>
+      period: optional<Period>
+      assigner: optional<Reference>
+  CodeableConcept:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      coding: optional<list<Coding>>
+      text: optional<string>
+  Coding:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      system: optional<uri>
+      version: optional<string>
+      code: optional<code>
+      display: optional<string>
+      userSelected: optional<boolean>
+  QuantityComparator:
+    enum:
+      []
+      # TODO: enums support non alphanumerics
+      # - <
+      # - <=
+      # - '>='
+      # - '>'
+  Quantity:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      comparator: optional<QuantityComparator>
+      unit: optional<string>
+      system: optional<uri>
+      code: optional<code>
+  DurationComparator:
+    enum:
+      []
+      # TODO: enums support non alphanumerics
+      # - <
+      # - <=
+      # - '>='
+      # - '>'
+  Duration:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      comparator: optional<DurationComparator>
+      unit: optional<string>
+      system: optional<uri>
+      code: optional<code>
+  DistanceComparator:
+    enum:
+      []
+      # - <
+      # - <=
+      # - ">="
+      # - ">"
+  Distance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      comparator: optional<DistanceComparator>
+      unit: optional<string>
+      system: optional<uri>
+      code: optional<code>
+  CountComparator:
+    enum:
+      []
+      # - <
+      # - <=
+      # - ">="
+      # - ">"
+  Count:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      comparator: optional<CountComparator>
+      unit: optional<string>
+      system: optional<uri>
+      code: optional<code>
+  Money:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      currency: optional<code>
+  AgeComparator:
+    enum:
+      []
+      # - <
+      # - <=
+      # - ">="
+      # - ">"
+  Age:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      value: optional<decimal>
+      comparator: optional<AgeComparator>
+      unit: optional<string>
+      system: optional<uri>
+      code: optional<code>
+  Range:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      low: optional<Quantity>
+      high: optional<Quantity>
+  Period:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      start: optional<dateTime>
+      end: optional<dateTime>
+  Ratio:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      numerator: optional<Quantity>
+      denominator: optional<Quantity>
+  Reference:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      reference: optional<string>
+      type: optional<uri>
+      identifier: optional<Identifier>
+      display: optional<string>
+      resource: optional<ResourceList>
+  SampledData:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      origin: Quantity
+      period: optional<decimal>
+      factor: optional<decimal>
+      lowerLimit: optional<decimal>
+      upperLimit: optional<decimal>
+      dimensions: optional<positiveInt>
+      data: optional<string>
+  Signature:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      type: list<Coding>
+      when: optional<instant>
+      who: Reference
+      onBehalfOf: optional<Reference>
+      targetFormat: optional<code>
+      sigFormat: optional<code>
+      data: optional<base64Binary>
+  HumannameUse:
+    enum:
+      - usual
+      - official
+      - temp
+      - nickname
+      - anonymous
+      - old
+      - maiden
+  HumanName:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      use: optional<HumannameUse>
+      text: optional<string>
+      family: optional<string>
+      given: optional<list<string>>
+      prefix: optional<list<string>>
+      suffix: optional<list<string>>
+      period: optional<Period>
+  AddressUse:
+    enum:
+      - home
+      - work
+      - temp
+      - old
+      - billing
+  AddressType:
+    enum:
+      - postal
+      - physical
+      - both
+  Address:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      use: optional<AddressUse>
+      type: optional<AddressType>
+      text: optional<string>
+      line: optional<list<string>>
+      city: optional<string>
+      district: optional<string>
+      state: optional<string>
+      postalCode: optional<string>
+      country: optional<string>
+      period: optional<Period>
+  ContactpointSystem:
+    enum:
+      - phone
+      - fax
+      - email
+      - pager
+      - url
+      - sms
+      - other
+  ContactpointUse:
+    enum:
+      - home
+      - work
+      - temp
+      - old
+      - mobile
+  ContactPoint:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      system: optional<ContactpointSystem>
+      value: optional<string>
+      use: optional<ContactpointUse>
+      rank: optional<positiveInt>
+      period: optional<Period>
+  Timing:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      event: optional<list<dateTime>>
+      repeat: optional<Timing_Repeat>
+      code: optional<CodeableConcept>
+  Timing_repeatDurationunit:
+    enum:
+      - s
+      - min
+      - h
+      - d
+      - wk
+      - mo
+      - a
+  Timing_repeatPeriodunit:
+    enum:
+      - s
+      - min
+      - h
+      - d
+      - wk
+      - mo
+      - a
+  Timing_repeatWhenItem:
+    enum:
+      - MORN
+      # - MORN.early
+      # - MORN.late
+      - NOON
+      - AFT
+      # - AFT.early
+      # - AFT.late
+      - EVE
+      # - EVE.early
+      # - EVE.late
+      - NIGHT
+      - PHS
+      - HS
+      - WAKE
+      - C
+      - CM
+      - CD
+      - CV
+      - AC
+      - ACM
+      - ACD
+      - ACV
+      - PC
+      - PCM
+      - PCD
+      - PCV
+  Timing_Repeat:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      boundsDuration: optional<Duration>
+      boundsRange: optional<Range>
+      boundsPeriod: optional<Period>
+      count: optional<positiveInt>
+      countMax: optional<positiveInt>
+      duration: optional<decimal>
+      durationMax: optional<decimal>
+      durationUnit: optional<Timing_repeatDurationunit>
+      frequency: optional<positiveInt>
+      frequencyMax: optional<positiveInt>
+      period: optional<decimal>
+      periodMax: optional<decimal>
+      periodUnit: optional<Timing_repeatPeriodunit>
+      dayOfWeek: optional<list<code>>
+      timeOfDay: optional<list<time>>
+      when: optional<list<Timing_repeatWhenItem>>
+      offset: optional<unsignedInt>
+  Meta:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      versionId: optional<id>
+      lastUpdated: optional<instant>
+      source: optional<uri>
+      profile: optional<list<canonical>>
+      security: optional<list<Coding>>
+      tag: optional<list<Coding>>
+      project: optional<uri>
+      author: optional<Reference>
+  ContactDetail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      name: optional<string>
+      telecom: optional<list<ContactPoint>>
+  ContributorType:
+    enum:
+      - author
+      - editor
+      - reviewer
+      - endorser
+  Contributor:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      type: optional<ContributorType>
+      name: optional<string>
+      contact: optional<list<ContactDetail>>
+  DataRequirement:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      type: optional<code>
+      profile: optional<list<canonical>>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      mustSupport: optional<list<string>>
+      codeFilter: optional<list<DataRequirement_CodeFilter>>
+      dateFilter: optional<list<DataRequirement_DateFilter>>
+      limit: optional<positiveInt>
+      sort: optional<list<DataRequirement_Sort>>
+  DataRequirement_CodeFilter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      searchParam: optional<string>
+      valueSet: optional<canonical>
+      code: optional<list<Coding>>
+  DataRequirement_DateFilter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      searchParam: optional<string>
+      valueDateTime: optional<string>
+      valuePeriod: optional<Period>
+      valueDuration: optional<Duration>
+  Datarequirement_sortDirection:
+    enum:
+      - ascending
+      - descending
+  DataRequirement_Sort:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      direction: optional<Datarequirement_sortDirection>
+  ParameterDefinition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      name: optional<code>
+      use: optional<code>
+      min: optional<integer>
+      max: optional<string>
+      documentation: optional<string>
+      type: optional<code>
+      profile: optional<canonical>
+  RelatedartifactType:
+    enum:
+      - documentation
+      - justification
+      - citation
+      - predecessor
+      - successor
+      # - derived-from
+      # - depends-on
+      # - composed-of
+  RelatedArtifact:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      type: optional<RelatedartifactType>
+      label: optional<string>
+      display: optional<string>
+      citation: optional<markdown>
+      url: optional<url>
+      document: optional<Attachment>
+      resource: optional<canonical>
+  TriggerdefinitionType:
+    enum:
+      # - named-event
+      - periodic
+      # - data-changed
+      # - data-added
+      # - data-modified
+      # - data-removed
+      # - data-accessed
+      # - data-access-ended
+  TriggerDefinition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      type: optional<TriggerdefinitionType>
+      name: optional<string>
+      timingTiming: optional<Timing>
+      timingReference: optional<Reference>
+      timingDate: optional<string>
+      timingDateTime: optional<string>
+      data: optional<list<DataRequirement>>
+      condition: optional<Expression>
+  UsageContext:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      code: Coding
+      valueCodeableConcept: optional<CodeableConcept>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueReference: optional<Reference>
+  Dosage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<integer>
+      text: optional<string>
+      additionalInstruction: optional<list<CodeableConcept>>
+      patientInstruction: optional<string>
+      timing: optional<Timing>
+      asNeededBoolean: optional<boolean>
+      asNeededCodeableConcept: optional<CodeableConcept>
+      site: optional<CodeableConcept>
+      route: optional<CodeableConcept>
+      method: optional<CodeableConcept>
+      doseAndRate: optional<list<Dosage_DoseAndRate>>
+      maxDosePerPeriod: optional<Ratio>
+      maxDosePerAdministration: optional<Quantity>
+      maxDosePerLifetime: optional<Quantity>
+  Dosage_DoseAndRate:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      doseRange: optional<Range>
+      doseQuantity: optional<Quantity>
+      rateRatio: optional<Ratio>
+      rateRange: optional<Range>
+      rateQuantity: optional<Quantity>
+  Population:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      ageRange: optional<Range>
+      ageCodeableConcept: optional<CodeableConcept>
+      gender: optional<CodeableConcept>
+      race: optional<CodeableConcept>
+      physiologicalCondition: optional<CodeableConcept>
+  ProductShelfLife:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      type: CodeableConcept
+      period: Quantity
+      specialPrecautionsForStorage: optional<list<CodeableConcept>>
+  ProdCharacteristic:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      height: optional<Quantity>
+      width: optional<Quantity>
+      depth: optional<Quantity>
+      weight: optional<Quantity>
+      nominalVolume: optional<Quantity>
+      externalDiameter: optional<Quantity>
+      shape: optional<string>
+      color: optional<list<string>>
+      imprint: optional<list<string>>
+      image: optional<list<Attachment>>
+      scoring: optional<CodeableConcept>
+  MarketingStatus:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      country: CodeableConcept
+      jurisdiction: optional<CodeableConcept>
+      status: CodeableConcept
+      dateRange: Period
+      restoreDate: optional<dateTime>
+  SubstanceAmount:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      amountQuantity: optional<Quantity>
+      amountRange: optional<Range>
+      amountString: optional<string>
+      amountType: optional<CodeableConcept>
+      amountText: optional<string>
+      referenceRange: optional<SubstanceAmount_ReferenceRange>
+  SubstanceAmount_ReferenceRange:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      lowLimit: optional<Quantity>
+      highLimit: optional<Quantity>
+  ExpressionLanguage:
+    enum:
+      - text/cql
+      - text/fhirpath
+      - application/x-fhir-query
+  Expression:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      description: optional<string>
+      name: optional<id>
+      language: optional<ExpressionLanguage>
+      expression: optional<string>
+      reference: optional<uri>
+  ElementdefinitionRepresentationItem:
+    enum:
+      - xmlAttr
+      - xmlText
+      - typeAttr
+      - cdaText
+      - xhtml
+  ElementDefinition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      representation: optional<list<ElementdefinitionRepresentationItem>>
+      sliceName: optional<string>
+      sliceIsConstraining: optional<boolean>
+      label: optional<string>
+      code: optional<list<Coding>>
+      slicing: optional<ElementDefinition_Slicing>
+      short: optional<string>
+      definition: optional<markdown>
+      comment: optional<markdown>
+      requirements: optional<markdown>
+      alias: optional<list<string>>
+      min: optional<unsignedInt>
+      max: optional<string>
+      base: optional<ElementDefinition_Base>
+      contentReference: optional<uri>
+      type: optional<list<ElementDefinition_Type>>
+      defaultValueBase64Binary: optional<string>
+      defaultValueBoolean: optional<boolean>
+      defaultValueCanonical: optional<string>
+      defaultValueCode: optional<string>
+      defaultValueDate: optional<string>
+      defaultValueDateTime: optional<string>
+      defaultValueDecimal: optional<double>
+      defaultValueId: optional<string>
+      defaultValueInstant: optional<string>
+      defaultValueInteger: optional<double>
+      defaultValueMarkdown: optional<string>
+      defaultValueOid: optional<string>
+      defaultValuePositiveInt: optional<double>
+      defaultValueString: optional<string>
+      defaultValueTime: optional<string>
+      defaultValueUnsignedInt: optional<double>
+      defaultValueUri: optional<string>
+      defaultValueUrl: optional<string>
+      defaultValueUuid: optional<string>
+      defaultValueAddress: optional<Address>
+      defaultValueAge: optional<Age>
+      defaultValueAnnotation: optional<Annotation>
+      defaultValueAttachment: optional<Attachment>
+      defaultValueCodeableConcept: optional<CodeableConcept>
+      defaultValueCoding: optional<Coding>
+      defaultValueContactPoint: optional<ContactPoint>
+      defaultValueCount: optional<Count>
+      defaultValueDistance: optional<Distance>
+      defaultValueDuration: optional<Duration>
+      defaultValueHumanName: optional<HumanName>
+      defaultValueIdentifier: optional<Identifier>
+      defaultValueMoney: optional<Money>
+      defaultValuePeriod: optional<Period>
+      defaultValueQuantity: optional<Quantity>
+      defaultValueRange: optional<Range>
+      defaultValueRatio: optional<Ratio>
+      defaultValueReference: optional<Reference>
+      defaultValueSampledData: optional<SampledData>
+      defaultValueSignature: optional<Signature>
+      defaultValueTiming: optional<Timing>
+      defaultValueContactDetail: optional<ContactDetail>
+      defaultValueContributor: optional<Contributor>
+      defaultValueDataRequirement: optional<DataRequirement>
+      defaultValueExpression: optional<Expression>
+      defaultValueParameterDefinition: optional<ParameterDefinition>
+      defaultValueRelatedArtifact: optional<RelatedArtifact>
+      defaultValueTriggerDefinition: optional<TriggerDefinition>
+      defaultValueUsageContext: optional<UsageContext>
+      defaultValueDosage: optional<Dosage>
+      defaultValueMeta: optional<Meta>
+      meaningWhenMissing: optional<markdown>
+      orderMeaning: optional<string>
+      fixedBase64Binary: optional<string>
+      fixedBoolean: optional<boolean>
+      fixedCanonical: optional<string>
+      fixedCode: optional<string>
+      fixedDate: optional<string>
+      fixedDateTime: optional<string>
+      fixedDecimal: optional<double>
+      fixedId: optional<string>
+      fixedInstant: optional<string>
+      fixedInteger: optional<double>
+      fixedMarkdown: optional<string>
+      fixedOid: optional<string>
+      fixedPositiveInt: optional<double>
+      fixedString: optional<string>
+      fixedTime: optional<string>
+      fixedUnsignedInt: optional<double>
+      fixedUri: optional<string>
+      fixedUrl: optional<string>
+      fixedUuid: optional<string>
+      fixedAddress: optional<Address>
+      fixedAge: optional<Age>
+      fixedAnnotation: optional<Annotation>
+      fixedAttachment: optional<Attachment>
+      fixedCodeableConcept: optional<CodeableConcept>
+      fixedCoding: optional<Coding>
+      fixedContactPoint: optional<ContactPoint>
+      fixedCount: optional<Count>
+      fixedDistance: optional<Distance>
+      fixedDuration: optional<Duration>
+      fixedHumanName: optional<HumanName>
+      fixedIdentifier: optional<Identifier>
+      fixedMoney: optional<Money>
+      fixedPeriod: optional<Period>
+      fixedQuantity: optional<Quantity>
+      fixedRange: optional<Range>
+      fixedRatio: optional<Ratio>
+      fixedReference: optional<Reference>
+      fixedSampledData: optional<SampledData>
+      fixedSignature: optional<Signature>
+      fixedTiming: optional<Timing>
+      fixedContactDetail: optional<ContactDetail>
+      fixedContributor: optional<Contributor>
+      fixedDataRequirement: optional<DataRequirement>
+      fixedExpression: optional<Expression>
+      fixedParameterDefinition: optional<ParameterDefinition>
+      fixedRelatedArtifact: optional<RelatedArtifact>
+      fixedTriggerDefinition: optional<TriggerDefinition>
+      fixedUsageContext: optional<UsageContext>
+      fixedDosage: optional<Dosage>
+      fixedMeta: optional<Meta>
+      patternBase64Binary: optional<string>
+      patternBoolean: optional<boolean>
+      patternCanonical: optional<string>
+      patternCode: optional<string>
+      patternDate: optional<string>
+      patternDateTime: optional<string>
+      patternDecimal: optional<double>
+      patternId: optional<string>
+      patternInstant: optional<string>
+      patternInteger: optional<double>
+      patternMarkdown: optional<string>
+      patternOid: optional<string>
+      patternPositiveInt: optional<double>
+      patternString: optional<string>
+      patternTime: optional<string>
+      patternUnsignedInt: optional<double>
+      patternUri: optional<string>
+      patternUrl: optional<string>
+      patternUuid: optional<string>
+      patternAddress: optional<Address>
+      patternAge: optional<Age>
+      patternAnnotation: optional<Annotation>
+      patternAttachment: optional<Attachment>
+      patternCodeableConcept: optional<CodeableConcept>
+      patternCoding: optional<Coding>
+      patternContactPoint: optional<ContactPoint>
+      patternCount: optional<Count>
+      patternDistance: optional<Distance>
+      patternDuration: optional<Duration>
+      patternHumanName: optional<HumanName>
+      patternIdentifier: optional<Identifier>
+      patternMoney: optional<Money>
+      patternPeriod: optional<Period>
+      patternQuantity: optional<Quantity>
+      patternRange: optional<Range>
+      patternRatio: optional<Ratio>
+      patternReference: optional<Reference>
+      patternSampledData: optional<SampledData>
+      patternSignature: optional<Signature>
+      patternTiming: optional<Timing>
+      patternContactDetail: optional<ContactDetail>
+      patternContributor: optional<Contributor>
+      patternDataRequirement: optional<DataRequirement>
+      patternExpression: optional<Expression>
+      patternParameterDefinition: optional<ParameterDefinition>
+      patternRelatedArtifact: optional<RelatedArtifact>
+      patternTriggerDefinition: optional<TriggerDefinition>
+      patternUsageContext: optional<UsageContext>
+      patternDosage: optional<Dosage>
+      patternMeta: optional<Meta>
+      example: optional<list<ElementDefinition_Example>>
+      minValueDate: optional<string>
+      minValueDateTime: optional<string>
+      minValueInstant: optional<string>
+      minValueTime: optional<string>
+      minValueDecimal: optional<double>
+      minValueInteger: optional<double>
+      minValuePositiveInt: optional<double>
+      minValueUnsignedInt: optional<double>
+      minValueQuantity: optional<Quantity>
+      maxValueDate: optional<string>
+      maxValueDateTime: optional<string>
+      maxValueInstant: optional<string>
+      maxValueTime: optional<string>
+      maxValueDecimal: optional<double>
+      maxValueInteger: optional<double>
+      maxValuePositiveInt: optional<double>
+      maxValueUnsignedInt: optional<double>
+      maxValueQuantity: optional<Quantity>
+      maxLength: optional<integer>
+      condition: optional<list<id>>
+      constraint: optional<list<ElementDefinition_Constraint>>
+      mustSupport: optional<boolean>
+      isModifier: optional<boolean>
+      isModifierReason: optional<string>
+      isSummary: optional<boolean>
+      binding: optional<ElementDefinition_Binding>
+      mapping: optional<list<ElementDefinition_Mapping>>
+  Elementdefinition_slicingRules:
+    enum:
+      - closed
+      - open
+      - openAtEnd
+  ElementDefinition_Slicing:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      discriminator: optional<list<ElementDefinition_Discriminator>>
+      description: optional<string>
+      ordered: optional<boolean>
+      rules: optional<Elementdefinition_slicingRules>
+  Elementdefinition_discriminatorType:
+    enum:
+      - value
+      - exists
+      - pattern
+      - type
+      - profile
+  ElementDefinition_Discriminator:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Elementdefinition_discriminatorType>
+      path: optional<string>
+  ElementDefinition_Base:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      min: optional<unsignedInt>
+      max: optional<string>
+  Elementdefinition_typeAggregationItem:
+    enum:
+      - contained
+      - referenced
+      - bundled
+  Elementdefinition_typeVersioning:
+    enum:
+      - either
+      - independent
+      - specific
+  ElementDefinition_Type:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<uri>
+      profile: optional<list<canonical>>
+      targetProfile: optional<list<canonical>>
+      aggregation: optional<list<Elementdefinition_typeAggregationItem>>
+      versioning: optional<Elementdefinition_typeVersioning>
+  ElementDefinition_Example:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      label: optional<string>
+      valueBase64Binary: optional<string>
+      valueBoolean: optional<boolean>
+      valueCanonical: optional<string>
+      valueCode: optional<string>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+      valueId: optional<string>
+      valueInstant: optional<string>
+      valueInteger: optional<double>
+      valueMarkdown: optional<string>
+      valueOid: optional<string>
+      valuePositiveInt: optional<double>
+      valueString: optional<string>
+      valueTime: optional<string>
+      valueUnsignedInt: optional<double>
+      valueUri: optional<string>
+      valueUrl: optional<string>
+      valueUuid: optional<string>
+      valueAddress: optional<Address>
+      valueAge: optional<Age>
+      valueAnnotation: optional<Annotation>
+      valueAttachment: optional<Attachment>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueCoding: optional<Coding>
+      valueContactPoint: optional<ContactPoint>
+      valueCount: optional<Count>
+      valueDistance: optional<Distance>
+      valueDuration: optional<Duration>
+      valueHumanName: optional<HumanName>
+      valueIdentifier: optional<Identifier>
+      valueMoney: optional<Money>
+      valuePeriod: optional<Period>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueReference: optional<Reference>
+      valueSampledData: optional<SampledData>
+      valueSignature: optional<Signature>
+      valueTiming: optional<Timing>
+      valueContactDetail: optional<ContactDetail>
+      valueContributor: optional<Contributor>
+      valueDataRequirement: optional<DataRequirement>
+      valueExpression: optional<Expression>
+      valueParameterDefinition: optional<ParameterDefinition>
+      valueRelatedArtifact: optional<RelatedArtifact>
+      valueTriggerDefinition: optional<TriggerDefinition>
+      valueUsageContext: optional<UsageContext>
+      valueDosage: optional<Dosage>
+      valueMeta: optional<Meta>
+  Elementdefinition_constraintSeverity:
+    enum:
+      - error
+      - warning
+  ElementDefinition_Constraint:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      key: optional<id>
+      requirements: optional<string>
+      severity: optional<Elementdefinition_constraintSeverity>
+      human: optional<string>
+      expression: optional<string>
+      xpath: optional<string>
+      source: optional<canonical>
+  Elementdefinition_bindingStrength:
+    enum:
+      - required
+      - extensible
+      - preferred
+      - example
+  ElementDefinition_Binding:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      strength: optional<Elementdefinition_bindingStrength>
+      description: optional<string>
+      valueSet: optional<canonical>
+  ElementDefinition_Mapping:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identity: optional<id>
+      language: optional<code>
+      map: optional<string>
+      comment: optional<string>
+  AccountStatus:
+    enum:
+      - active
+      - inactive
+      - entered-in-error
+      - on-hold
+      - unknown
+  Account:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<AccountStatus>
+      type: optional<CodeableConcept>
+      name: optional<string>
+      subject: optional<list<Reference>>
+      servicePeriod: optional<Period>
+      coverage: optional<list<Account_Coverage>>
+      owner: optional<Reference>
+      description: optional<string>
+      guarantor: optional<list<Account_Guarantor>>
+      partOf: optional<Reference>
+  Account_Coverage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      coverage: Reference
+      priority: optional<positiveInt>
+  Account_Guarantor:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      party: Reference
+      onHold: optional<boolean>
+      period: optional<Period>
+  ActivitydefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ActivityDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      status: optional<ActivitydefinitionStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      library: optional<list<canonical>>
+      kind: optional<code>
+      profile: optional<canonical>
+      code: optional<CodeableConcept>
+      intent: optional<code>
+      priority: optional<code>
+      doNotPerform: optional<boolean>
+      timingTiming: optional<Timing>
+      timingDateTime: optional<string>
+      timingAge: optional<Age>
+      timingPeriod: optional<Period>
+      timingRange: optional<Range>
+      timingDuration: optional<Duration>
+      location: optional<Reference>
+      participant: optional<list<ActivityDefinition_Participant>>
+      productReference: optional<Reference>
+      productCodeableConcept: optional<CodeableConcept>
+      quantity: optional<Quantity>
+      dosage: optional<list<Dosage>>
+      bodySite: optional<list<CodeableConcept>>
+      specimenRequirement: optional<list<Reference>>
+      observationRequirement: optional<list<Reference>>
+      observationResultRequirement: optional<list<Reference>>
+      transform: optional<canonical>
+      dynamicValue: optional<list<ActivityDefinition_DynamicValue>>
+  ActivityDefinition_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<code>
+      role: optional<CodeableConcept>
+  ActivityDefinition_DynamicValue:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      expression: Expression
+  AdverseeventActuality:
+    enum:
+      - actual
+      - potential
+  AdverseEvent:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      actuality: optional<AdverseeventActuality>
+      category: optional<list<CodeableConcept>>
+      event: optional<CodeableConcept>
+      subject: Reference
+      encounter: optional<Reference>
+      date: optional<dateTime>
+      detected: optional<dateTime>
+      recordedDate: optional<dateTime>
+      resultingCondition: optional<list<Reference>>
+      location: optional<Reference>
+      seriousness: optional<CodeableConcept>
+      severity: optional<CodeableConcept>
+      outcome: optional<CodeableConcept>
+      recorder: optional<Reference>
+      contributor: optional<list<Reference>>
+      suspectEntity: optional<list<AdverseEvent_SuspectEntity>>
+      subjectMedicalHistory: optional<list<Reference>>
+      referenceDocument: optional<list<Reference>>
+      study: optional<list<Reference>>
+  AdverseEvent_SuspectEntity:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      instance: Reference
+      causality: optional<list<AdverseEvent_Causality>>
+  AdverseEvent_Causality:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      assessment: optional<CodeableConcept>
+      productRelatedness: optional<string>
+      author: optional<Reference>
+      method: optional<CodeableConcept>
+  AllergyintoleranceType:
+    enum:
+      - allergy
+      - intolerance
+  AllergyintoleranceCategoryItem:
+    enum:
+      - food
+      - medication
+      - environment
+      - biologic
+  AllergyintoleranceCriticality:
+    enum:
+      - low
+      - high
+      # - unable-to-assess
+  AllergyIntolerance:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      clinicalStatus: optional<CodeableConcept>
+      verificationStatus: optional<CodeableConcept>
+      type: optional<AllergyintoleranceType>
+      category: optional<list<AllergyintoleranceCategoryItem>>
+      criticality: optional<AllergyintoleranceCriticality>
+      code: optional<CodeableConcept>
+      patient: Reference
+      encounter: optional<Reference>
+      onsetDateTime: optional<string>
+      onsetAge: optional<Age>
+      onsetPeriod: optional<Period>
+      onsetRange: optional<Range>
+      onsetString: optional<string>
+      recordedDate: optional<dateTime>
+      recorder: optional<Reference>
+      asserter: optional<Reference>
+      lastOccurrence: optional<dateTime>
+      note: optional<list<Annotation>>
+      reaction: optional<list<AllergyIntolerance_Reaction>>
+  Allergyintolerance_reactionSeverity:
+    enum:
+      - mild
+      - moderate
+      - severe
+  AllergyIntolerance_Reaction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      substance: optional<CodeableConcept>
+      manifestation: list<CodeableConcept>
+      description: optional<string>
+      onset: optional<dateTime>
+      severity: optional<Allergyintolerance_reactionSeverity>
+      exposureRoute: optional<CodeableConcept>
+      note: optional<list<Annotation>>
+  AppointmentStatus:
+    enum:
+      - proposed
+      - pending
+      - booked
+      - arrived
+      - fulfilled
+      - cancelled
+      - noshow
+      # - entered-in-error
+      # - checked-in
+      - waitlist
+  Appointment:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<AppointmentStatus>
+      cancelationReason: optional<CodeableConcept>
+      serviceCategory: optional<list<CodeableConcept>>
+      serviceType: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      appointmentType: optional<CodeableConcept>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      priority: optional<unsignedInt>
+      description: optional<string>
+      supportingInformation: optional<list<Reference>>
+      start: optional<instant>
+      end: optional<instant>
+      minutesDuration: optional<positiveInt>
+      slot: optional<list<Reference>>
+      created: optional<dateTime>
+      comment: optional<string>
+      patientInstruction: optional<string>
+      basedOn: optional<list<Reference>>
+      participant: list<Appointment_Participant>
+      requestedPeriod: optional<list<Period>>
+  Appointment_participantRequired:
+    enum:
+      - required
+      - optional
+      # - information-only
+  Appointment_participantStatus:
+    enum:
+      - accepted
+      - declined
+      - tentative
+      # - needs-action
+  Appointment_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<list<CodeableConcept>>
+      actor: optional<Reference>
+      required: optional<Appointment_participantRequired>
+      status: optional<Appointment_participantStatus>
+      period: optional<Period>
+  AppointmentResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      appointment: Reference
+      start: optional<instant>
+      end: optional<instant>
+      participantType: optional<list<CodeableConcept>>
+      actor: optional<Reference>
+      participantStatus: optional<code>
+      comment: optional<string>
+  AuditeventAction:
+    enum:
+      - C
+      - R
+      - U
+      - D
+      - E
+  AuditeventOutcome:
+    enum:
+      []
+      # - "0"
+      # - "4"
+      # - "8"
+      # - "12"
+  AuditEvent:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: Coding
+      subtype: optional<list<Coding>>
+      action: optional<AuditeventAction>
+      period: optional<Period>
+      recorded: optional<instant>
+      outcome: optional<AuditeventOutcome>
+      outcomeDesc: optional<string>
+      purposeOfEvent: optional<list<CodeableConcept>>
+      agent: list<AuditEvent_Agent>
+      source: AuditEvent_Source
+      entity: optional<list<AuditEvent_Entity>>
+  AuditEvent_Agent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      role: optional<list<CodeableConcept>>
+      who: optional<Reference>
+      altId: optional<string>
+      name: optional<string>
+      requestor: optional<boolean>
+      location: optional<Reference>
+      policy: optional<list<uri>>
+      media: optional<Coding>
+      network: optional<AuditEvent_Network>
+      purposeOfUse: optional<list<CodeableConcept>>
+  Auditevent_networkType:
+    enum:
+      []
+      # - "1"
+      # - "2"
+      # - "3"
+      # - "4"
+      # - "5"
+  AuditEvent_Network:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      address: optional<string>
+      type: optional<Auditevent_networkType>
+  AuditEvent_Source:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      site: optional<string>
+      observer: Reference
+      type: optional<list<Coding>>
+  AuditEvent_Entity:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      what: optional<Reference>
+      type: optional<Coding>
+      role: optional<Coding>
+      lifecycle: optional<Coding>
+      securityLabel: optional<list<Coding>>
+      name: optional<string>
+      description: optional<string>
+      query: optional<base64Binary>
+      detail: optional<list<AuditEvent_Detail>>
+  AuditEvent_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<string>
+      valueString: optional<string>
+      valueBase64Binary: optional<string>
+  Basic:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      code: CodeableConcept
+      subject: optional<Reference>
+      created: optional<date>
+      author: optional<Reference>
+  Binary:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      contentType: optional<code>
+      securityContext: optional<Reference>
+      data: optional<base64Binary>
+  BiologicallyderivedproductProductcategory:
+    enum:
+      - organ
+      - tissue
+      - fluid
+      - cells
+      - biologicalAgent
+  BiologicallyderivedproductStatus:
+    enum:
+      - available
+      - unavailable
+  BiologicallyDerivedProduct:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      productCategory: optional<BiologicallyderivedproductProductcategory>
+      productCode: optional<CodeableConcept>
+      status: optional<BiologicallyderivedproductStatus>
+      request: optional<list<Reference>>
+      quantity: optional<integer>
+      parent: optional<list<Reference>>
+      collection: optional<BiologicallyDerivedProduct_Collection>
+      processing: optional<list<BiologicallyDerivedProduct_Processing>>
+      manipulation: optional<BiologicallyDerivedProduct_Manipulation>
+      storage: optional<list<BiologicallyDerivedProduct_Storage>>
+  BiologicallyDerivedProduct_Collection:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      collector: optional<Reference>
+      source: optional<Reference>
+      collectedDateTime: optional<string>
+      collectedPeriod: optional<Period>
+  BiologicallyDerivedProduct_Processing:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      procedure: optional<CodeableConcept>
+      additive: optional<Reference>
+      timeDateTime: optional<string>
+      timePeriod: optional<Period>
+  BiologicallyDerivedProduct_Manipulation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      timeDateTime: optional<string>
+      timePeriod: optional<Period>
+  Biologicallyderivedproduct_storageScale:
+    enum:
+      - farenheit
+      - celsius
+      - kelvin
+  BiologicallyDerivedProduct_Storage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      temperature: optional<decimal>
+      scale: optional<Biologicallyderivedproduct_storageScale>
+      duration: optional<Period>
+  BodyStructure:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      morphology: optional<CodeableConcept>
+      location: optional<CodeableConcept>
+      locationQualifier: optional<list<CodeableConcept>>
+      description: optional<string>
+      image: optional<list<Attachment>>
+      patient: Reference
+  BundleType:
+    enum:
+      - document
+      - message
+      - transaction
+      # - transaction-response
+      - batch
+      # - batch-response
+      - history
+      - searchset
+      - collection
+  Bundle:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      identifier: optional<Identifier>
+      type: optional<BundleType>
+      timestamp: optional<instant>
+      total: optional<unsignedInt>
+      link: optional<list<Bundle_Link>>
+      entry: optional<list<Bundle_Entry>>
+      signature: optional<Signature>
+  Bundle_Link:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      relation: optional<string>
+      url: optional<uri>
+  Bundle_Entry:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      link: optional<list<Bundle_Link>>
+      fullUrl: optional<uri>
+      resource: optional<ResourceList>
+      search: optional<Bundle_Search>
+      request: optional<Bundle_Request>
+      response: optional<Bundle_Response>
+  Bundle_searchMode:
+    enum:
+      - match
+      - include
+      - outcome
+  Bundle_Search:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Bundle_searchMode>
+      score: optional<decimal>
+  Bundle_requestMethod:
+    enum:
+      - GET
+      - HEAD
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+  Bundle_Request:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      method: optional<Bundle_requestMethod>
+      url: optional<uri>
+      ifNoneMatch: optional<string>
+      ifModifiedSince: optional<instant>
+      ifMatch: optional<string>
+      ifNoneExist: optional<string>
+  Bundle_Response:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      status: optional<string>
+      location: optional<uri>
+      etag: optional<string>
+      lastModified: optional<instant>
+      outcome: optional<ResourceList>
+  CapabilitystatementStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  CapabilitystatementKind:
+    enum:
+      - instance
+      - capability
+      - requirements
+  CapabilitystatementFhirversion:
+    enum:
+      []
+      # - "0.01"
+      # - "0.05"
+      # - "0.06"
+      # - "0.11"
+      # - 0.0.80
+      # - 0.0.81
+      # - 0.0.82
+      # - 0.4.0
+      # - 0.5.0
+      # - 1.0.0
+      # - 1.0.1
+      # - 1.0.2
+      # - 1.1.0
+      # - 1.4.0
+      # - 1.6.0
+      # - 1.8.0
+      # - 3.0.0
+      # - 3.0.1
+      # - 3.3.0
+      # - 3.5.0
+      # - 4.0.0
+      # - 4.0.1
+  CapabilityStatement:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<CapabilitystatementStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      kind: optional<CapabilitystatementKind>
+      instantiates: optional<list<canonical>>
+      imports: optional<list<canonical>>
+      software: optional<CapabilityStatement_Software>
+      implementation: optional<CapabilityStatement_Implementation>
+      fhirVersion: optional<CapabilitystatementFhirversion>
+      format: optional<list<code>>
+      patchFormat: optional<list<code>>
+      implementationGuide: optional<list<canonical>>
+      rest: optional<list<CapabilityStatement_Rest>>
+      messaging: optional<list<CapabilityStatement_Messaging>>
+      document: optional<list<CapabilityStatement_Document>>
+  CapabilityStatement_Software:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      version: optional<string>
+      releaseDate: optional<dateTime>
+  CapabilityStatement_Implementation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      url: optional<url>
+      custodian: optional<Reference>
+  Capabilitystatement_restMode:
+    enum:
+      - client
+      - server
+  CapabilityStatement_Rest:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Capabilitystatement_restMode>
+      documentation: optional<markdown>
+      security: optional<CapabilityStatement_Security>
+      resource: optional<list<CapabilityStatement_Resource>>
+      interaction: optional<list<CapabilityStatement_Interaction1>>
+      searchParam: optional<list<CapabilityStatement_SearchParam>>
+      operation: optional<list<CapabilityStatement_Operation>>
+      compartment: optional<list<canonical>>
+  CapabilityStatement_Security:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      cors: optional<boolean>
+      service: optional<list<CodeableConcept>>
+      description: optional<markdown>
+  Capabilitystatement_resourceVersioning:
+    enum:
+      # - no-version
+      - versioned
+      # - versioned-update
+  Capabilitystatement_resourceConditionalread:
+    enum:
+      []
+      # - not-supported
+      # - modified-since
+      # - not-match
+      # - full-support
+  Capabilitystatement_resourceConditionaldelete:
+    enum:
+      # - not-supported
+      - single
+      - multiple
+  Capabilitystatement_resourceReferencepolicyItem:
+    enum:
+      - literal
+      - logical
+      - resolves
+      - enforced
+      - local
+  CapabilityStatement_Resource:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<code>
+      profile: optional<canonical>
+      supportedProfile: optional<list<canonical>>
+      documentation: optional<markdown>
+      interaction: optional<list<CapabilityStatement_Interaction>>
+      versioning: optional<Capabilitystatement_resourceVersioning>
+      readHistory: optional<boolean>
+      updateCreate: optional<boolean>
+      conditionalCreate: optional<boolean>
+      conditionalRead: optional<Capabilitystatement_resourceConditionalread>
+      conditionalUpdate: optional<boolean>
+      conditionalDelete: optional<Capabilitystatement_resourceConditionaldelete>
+      referencePolicy: optional<list<Capabilitystatement_resourceReferencepolicyItem>>
+      searchInclude: optional<list<string>>
+      searchRevInclude: optional<list<string>>
+      searchParam: optional<list<CapabilityStatement_SearchParam>>
+      operation: optional<list<CapabilityStatement_Operation>>
+  Capabilitystatement_interactionCode:
+    enum:
+      - read
+      - vread
+      - update
+      - patch
+      - delete
+      # - history-instance
+      # - history-type
+      - create
+      # - search-type
+  CapabilityStatement_Interaction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<Capabilitystatement_interactionCode>
+      documentation: optional<markdown>
+  Capabilitystatement_searchparamType:
+    enum:
+      - number
+      - date
+      - string
+      - token
+      - reference
+      - composite
+      - quantity
+      - uri
+      - special
+  CapabilityStatement_SearchParam:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      definition: optional<canonical>
+      type: optional<Capabilitystatement_searchparamType>
+      documentation: optional<markdown>
+  CapabilityStatement_Operation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      definition: canonical
+      documentation: optional<markdown>
+  Capabilitystatement_interaction1Code:
+    enum:
+      - transaction
+      - batch
+      # - search-system
+      # - history-system
+  CapabilityStatement_Interaction1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<Capabilitystatement_interaction1Code>
+      documentation: optional<markdown>
+  CapabilityStatement_Messaging:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      endpoint: optional<list<CapabilityStatement_Endpoint>>
+      reliableCache: optional<unsignedInt>
+      documentation: optional<markdown>
+      supportedMessage: optional<list<CapabilityStatement_SupportedMessage>>
+  CapabilityStatement_Endpoint:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      protocol: Coding
+      address: optional<url>
+  Capabilitystatement_supportedmessageMode:
+    enum:
+      - sender
+      - receiver
+  CapabilityStatement_SupportedMessage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Capabilitystatement_supportedmessageMode>
+      definition: canonical
+  Capabilitystatement_documentMode:
+    enum:
+      - producer
+      - consumer
+  CapabilityStatement_Document:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Capabilitystatement_documentMode>
+      documentation: optional<markdown>
+      profile: canonical
+  CarePlan:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      replaces: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      intent: optional<code>
+      category: optional<list<CodeableConcept>>
+      title: optional<string>
+      description: optional<string>
+      subject: Reference
+      encounter: optional<Reference>
+      period: optional<Period>
+      created: optional<dateTime>
+      author: optional<Reference>
+      contributor: optional<list<Reference>>
+      careTeam: optional<list<Reference>>
+      addresses: optional<list<Reference>>
+      supportingInfo: optional<list<Reference>>
+      goal: optional<list<Reference>>
+      activity: optional<list<CarePlan_Activity>>
+      note: optional<list<Annotation>>
+  CarePlan_Activity:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      outcomeCodeableConcept: optional<list<CodeableConcept>>
+      outcomeReference: optional<list<Reference>>
+      progress: optional<list<Annotation>>
+      reference: optional<Reference>
+      detail: optional<CarePlan_Detail>
+  Careplan_detailStatus:
+    enum:
+      # - not-started
+      - scheduled
+      # - in-progress
+      # - on-hold
+      - completed
+      - cancelled
+      - stopped
+      - unknown
+      # - entered-in-error
+  CarePlan_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      kind: optional<code>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      code: optional<CodeableConcept>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      goal: optional<list<Reference>>
+      status: optional<Careplan_detailStatus>
+      statusReason: optional<CodeableConcept>
+      doNotPerform: optional<boolean>
+      scheduledTiming: optional<Timing>
+      scheduledPeriod: optional<Period>
+      scheduledString: optional<string>
+      location: optional<Reference>
+      performer: optional<list<Reference>>
+      productCodeableConcept: optional<CodeableConcept>
+      productReference: optional<Reference>
+      dailyAmount: optional<Quantity>
+      quantity: optional<Quantity>
+      description: optional<string>
+  CareteamStatus:
+    enum:
+      - proposed
+      - active
+      - suspended
+      - inactive
+      # - entered-in-error
+  CareTeam:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<CareteamStatus>
+      category: optional<list<CodeableConcept>>
+      name: optional<string>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      period: optional<Period>
+      participant: optional<list<CareTeam_Participant>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      managingOrganization: optional<list<Reference>>
+      telecom: optional<list<ContactPoint>>
+      note: optional<list<Annotation>>
+  CareTeam_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      role: optional<list<CodeableConcept>>
+      member: optional<Reference>
+      onBehalfOf: optional<Reference>
+      period: optional<Period>
+  CatalogentryStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  CatalogEntry:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: optional<CodeableConcept>
+      orderable: optional<boolean>
+      referencedItem: Reference
+      additionalIdentifier: optional<list<Identifier>>
+      classification: optional<list<CodeableConcept>>
+      status: optional<CatalogentryStatus>
+      validityPeriod: optional<Period>
+      validTo: optional<dateTime>
+      lastUpdated: optional<dateTime>
+      additionalCharacteristic: optional<list<CodeableConcept>>
+      additionalClassification: optional<list<CodeableConcept>>
+      relatedEntry: optional<list<CatalogEntry_RelatedEntry>>
+  Catalogentry_relatedentryRelationtype:
+    enum:
+      - triggers
+      # - is-replaced-by
+  CatalogEntry_RelatedEntry:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      relationtype: optional<Catalogentry_relatedentryRelationtype>
+      item: Reference
+  ChargeitemStatus:
+    enum:
+      - planned
+      - billable
+      # - not-billable
+      - aborted
+      - billed
+      # - entered-in-error
+      - unknown
+  ChargeItem:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      definitionUri: optional<list<uri>>
+      definitionCanonical: optional<list<canonical>>
+      status: optional<ChargeitemStatus>
+      partOf: optional<list<Reference>>
+      code: CodeableConcept
+      subject: Reference
+      context: optional<Reference>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      performer: optional<list<ChargeItem_Performer>>
+      performingOrganization: optional<Reference>
+      requestingOrganization: optional<Reference>
+      costCenter: optional<Reference>
+      quantity: optional<Quantity>
+      bodysite: optional<list<CodeableConcept>>
+      factorOverride: optional<decimal>
+      priceOverride: optional<Money>
+      overrideReason: optional<string>
+      enterer: optional<Reference>
+      enteredDate: optional<dateTime>
+      reason: optional<list<CodeableConcept>>
+      service: optional<list<Reference>>
+      productReference: optional<Reference>
+      productCodeableConcept: optional<CodeableConcept>
+      account: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      supportingInformation: optional<list<Reference>>
+  ChargeItem_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+  ChargeitemdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ChargeItemDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      title: optional<string>
+      derivedFromUri: optional<list<uri>>
+      partOf: optional<list<canonical>>
+      replaces: optional<list<canonical>>
+      status: optional<ChargeitemdefinitionStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      code: optional<CodeableConcept>
+      instance: optional<list<Reference>>
+      applicability: optional<list<ChargeItemDefinition_Applicability>>
+      propertyGroup: optional<list<ChargeItemDefinition_PropertyGroup>>
+  ChargeItemDefinition_Applicability:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      language: optional<string>
+      expression: optional<string>
+  ChargeItemDefinition_PropertyGroup:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      applicability: optional<list<ChargeItemDefinition_Applicability>>
+      priceComponent: optional<list<ChargeItemDefinition_PriceComponent>>
+  ChargeItemDefinition_PriceComponent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<code>
+      code: optional<CodeableConcept>
+      factor: optional<decimal>
+      amount: optional<Money>
+  ClaimUse:
+    enum:
+      - claim
+      - preauthorization
+      - predetermination
+  Claim:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      type: CodeableConcept
+      subType: optional<CodeableConcept>
+      use: optional<ClaimUse>
+      patient: Reference
+      billablePeriod: optional<Period>
+      created: optional<dateTime>
+      enterer: optional<Reference>
+      insurer: optional<Reference>
+      provider: Reference
+      priority: CodeableConcept
+      fundsReserve: optional<CodeableConcept>
+      related: optional<list<Claim_Related>>
+      prescription: optional<Reference>
+      originalPrescription: optional<Reference>
+      payee: optional<Claim_Payee>
+      referral: optional<Reference>
+      facility: optional<Reference>
+      careTeam: optional<list<Claim_CareTeam>>
+      supportingInfo: optional<list<Claim_SupportingInfo>>
+      diagnosis: optional<list<Claim_Diagnosis>>
+      procedure: optional<list<Claim_Procedure>>
+      insurance: list<Claim_Insurance>
+      accident: optional<Claim_Accident>
+      item: optional<list<Claim_Item>>
+      total: optional<Money>
+  Claim_Related:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      claim: optional<Reference>
+      relationship: optional<CodeableConcept>
+      reference: optional<Identifier>
+  Claim_Payee:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      party: optional<Reference>
+  Claim_CareTeam:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      provider: Reference
+      responsible: optional<boolean>
+      role: optional<CodeableConcept>
+      qualification: optional<CodeableConcept>
+  Claim_SupportingInfo:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      category: CodeableConcept
+      code: optional<CodeableConcept>
+      timingDate: optional<string>
+      timingPeriod: optional<Period>
+      valueBoolean: optional<boolean>
+      valueString: optional<string>
+      valueQuantity: optional<Quantity>
+      valueAttachment: optional<Attachment>
+      valueReference: optional<Reference>
+      reason: optional<CodeableConcept>
+  Claim_Diagnosis:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      diagnosisCodeableConcept: optional<CodeableConcept>
+      diagnosisReference: optional<Reference>
+      type: optional<list<CodeableConcept>>
+      onAdmission: optional<CodeableConcept>
+      packageCode: optional<CodeableConcept>
+  Claim_Procedure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      type: optional<list<CodeableConcept>>
+      date: optional<dateTime>
+      procedureCodeableConcept: optional<CodeableConcept>
+      procedureReference: optional<Reference>
+      udi: optional<list<Reference>>
+  Claim_Insurance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      focal: optional<boolean>
+      identifier: optional<Identifier>
+      coverage: Reference
+      businessArrangement: optional<string>
+      preAuthRef: optional<list<string>>
+      claimResponse: optional<Reference>
+  Claim_Accident:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      date: optional<date>
+      type: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+  Claim_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      careTeamSequence: optional<list<positiveInt>>
+      diagnosisSequence: optional<list<positiveInt>>
+      procedureSequence: optional<list<positiveInt>>
+      informationSequence: optional<list<positiveInt>>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      locationCodeableConcept: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+      bodySite: optional<CodeableConcept>
+      subSite: optional<list<CodeableConcept>>
+      encounter: optional<list<Reference>>
+      detail: optional<list<Claim_Detail>>
+  Claim_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+      subDetail: optional<list<Claim_SubDetail>>
+  Claim_SubDetail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+  ClaimResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      type: CodeableConcept
+      subType: optional<CodeableConcept>
+      use: optional<code>
+      patient: Reference
+      created: optional<dateTime>
+      insurer: Reference
+      requestor: optional<Reference>
+      request: optional<Reference>
+      outcome: optional<code>
+      disposition: optional<string>
+      preAuthRef: optional<string>
+      preAuthPeriod: optional<Period>
+      payeeType: optional<CodeableConcept>
+      item: optional<list<ClaimResponse_Item>>
+      addItem: optional<list<ClaimResponse_AddItem>>
+      adjudication: optional<list<ClaimResponse_Adjudication>>
+      total: optional<list<ClaimResponse_Total>>
+      payment: optional<ClaimResponse_Payment>
+      fundsReserve: optional<CodeableConcept>
+      formCode: optional<CodeableConcept>
+      form: optional<Attachment>
+      processNote: optional<list<ClaimResponse_ProcessNote>>
+      communicationRequest: optional<list<Reference>>
+      insurance: optional<list<ClaimResponse_Insurance>>
+      error: optional<list<ClaimResponse_Error>>
+  ClaimResponse_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemSequence: optional<positiveInt>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: list<ClaimResponse_Adjudication>
+      detail: optional<list<ClaimResponse_Detail>>
+  ClaimResponse_Adjudication:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      reason: optional<CodeableConcept>
+      amount: optional<Money>
+      value: optional<decimal>
+  ClaimResponse_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      detailSequence: optional<positiveInt>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: list<ClaimResponse_Adjudication>
+      subDetail: optional<list<ClaimResponse_SubDetail>>
+  ClaimResponse_SubDetail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subDetailSequence: optional<positiveInt>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ClaimResponse_Adjudication>>
+  ClaimResponse_AddItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemSequence: optional<list<positiveInt>>
+      detailSequence: optional<list<positiveInt>>
+      subdetailSequence: optional<list<positiveInt>>
+      provider: optional<list<Reference>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      locationCodeableConcept: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      bodySite: optional<CodeableConcept>
+      subSite: optional<list<CodeableConcept>>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: list<ClaimResponse_Adjudication>
+      detail: optional<list<ClaimResponse_Detail1>>
+  ClaimResponse_Detail1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: list<ClaimResponse_Adjudication>
+      subDetail: optional<list<ClaimResponse_SubDetail1>>
+  ClaimResponse_SubDetail1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: list<ClaimResponse_Adjudication>
+  ClaimResponse_Total:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      amount: Money
+  ClaimResponse_Payment:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      adjustment: optional<Money>
+      adjustmentReason: optional<CodeableConcept>
+      date: optional<date>
+      amount: Money
+      identifier: optional<Identifier>
+  Claimresponse_processnoteType:
+    enum:
+      - display
+      - print
+      - printoper
+  ClaimResponse_ProcessNote:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      number: optional<positiveInt>
+      type: optional<Claimresponse_processnoteType>
+      text: optional<string>
+      language: optional<CodeableConcept>
+  ClaimResponse_Insurance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      focal: optional<boolean>
+      coverage: Reference
+      businessArrangement: optional<string>
+      claimResponse: optional<Reference>
+  ClaimResponse_Error:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemSequence: optional<positiveInt>
+      detailSequence: optional<positiveInt>
+      subDetailSequence: optional<positiveInt>
+      code: CodeableConcept
+  ClinicalImpression:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      subject: Reference
+      encounter: optional<Reference>
+      effectiveDateTime: optional<string>
+      effectivePeriod: optional<Period>
+      date: optional<dateTime>
+      assessor: optional<Reference>
+      previous: optional<Reference>
+      problem: optional<list<Reference>>
+      investigation: optional<list<ClinicalImpression_Investigation>>
+      protocol: optional<list<uri>>
+      summary: optional<string>
+      finding: optional<list<ClinicalImpression_Finding>>
+      prognosisCodeableConcept: optional<list<CodeableConcept>>
+      prognosisReference: optional<list<Reference>>
+      supportingInfo: optional<list<Reference>>
+      note: optional<list<Annotation>>
+  ClinicalImpression_Investigation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      item: optional<list<Reference>>
+  ClinicalImpression_Finding:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemCodeableConcept: optional<CodeableConcept>
+      itemReference: optional<Reference>
+      basis: optional<string>
+  CodesystemStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  CodesystemHierarchymeaning:
+    enum:
+      []
+      # - grouped-by
+      # - is-a
+      # - part-of
+      # - classified-with
+  CodesystemContent:
+    enum:
+      # - not-present
+      - example
+      - fragment
+      - complete
+      - supplement
+  CodeSystem:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<CodesystemStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      caseSensitive: optional<boolean>
+      valueSet: optional<canonical>
+      hierarchyMeaning: optional<CodesystemHierarchymeaning>
+      compositional: optional<boolean>
+      versionNeeded: optional<boolean>
+      content: optional<CodesystemContent>
+      supplements: optional<canonical>
+      count: optional<unsignedInt>
+      filter: optional<list<CodeSystem_Filter>>
+      property: optional<list<CodeSystem_Property>>
+      concept: optional<list<CodeSystem_Concept>>
+  CodeSystem_Filter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      description: optional<string>
+      operator: optional<list<code>>
+      value: optional<string>
+  Codesystem_propertyType:
+    enum:
+      - code
+      - Coding
+      - string
+      - integer
+      - boolean
+      - dateTime
+      - decimal
+  CodeSystem_Property:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      uri: optional<uri>
+      description: optional<string>
+      type: optional<Codesystem_propertyType>
+  CodeSystem_Concept:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      display: optional<string>
+      definition: optional<string>
+      designation: optional<list<CodeSystem_Designation>>
+      property: optional<list<CodeSystem_Property1>>
+      concept: optional<list<CodeSystem_Concept>>
+  CodeSystem_Designation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      language: optional<code>
+      use: optional<Coding>
+      value: optional<string>
+  CodeSystem_Property1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      valueCode: optional<string>
+      valueCoding: optional<Coding>
+      valueString: optional<string>
+      valueInteger: optional<double>
+      valueBoolean: optional<boolean>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+  Communication:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      inResponseTo: optional<list<Reference>>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      priority: optional<code>
+      medium: optional<list<CodeableConcept>>
+      subject: optional<Reference>
+      topic: optional<CodeableConcept>
+      about: optional<list<Reference>>
+      encounter: optional<Reference>
+      sent: optional<dateTime>
+      received: optional<dateTime>
+      recipient: optional<list<Reference>>
+      sender: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      payload: optional<list<Communication_Payload>>
+      note: optional<list<Annotation>>
+  Communication_Payload:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      contentString: optional<string>
+      contentAttachment: optional<Attachment>
+      contentReference: optional<Reference>
+  CommunicationRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      replaces: optional<list<Reference>>
+      groupIdentifier: optional<Identifier>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      priority: optional<code>
+      doNotPerform: optional<boolean>
+      medium: optional<list<CodeableConcept>>
+      subject: optional<Reference>
+      about: optional<list<Reference>>
+      encounter: optional<Reference>
+      payload: optional<list<CommunicationRequest_Payload>>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      authoredOn: optional<dateTime>
+      requester: optional<Reference>
+      recipient: optional<list<Reference>>
+      sender: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+  CommunicationRequest_Payload:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      contentString: optional<string>
+      contentAttachment: optional<Attachment>
+      contentReference: optional<Reference>
+  CompartmentdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  CompartmentdefinitionCode:
+    enum:
+      - Patient
+      - Encounter
+      - RelatedPerson
+      - Practitioner
+      - Device
+  CompartmentDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      status: optional<CompartmentdefinitionStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      purpose: optional<markdown>
+      code: optional<CompartmentdefinitionCode>
+      search: optional<boolean>
+      resource: optional<list<CompartmentDefinition_Resource>>
+  CompartmentDefinition_Resource:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      param: optional<list<string>>
+      documentation: optional<string>
+  CompositionStatus:
+    enum:
+      - preliminary
+      - final
+      - amended
+      # - entered-in-error
+  Composition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      status: optional<CompositionStatus>
+      type: CodeableConcept
+      category: optional<list<CodeableConcept>>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      date: optional<dateTime>
+      author: list<Reference>
+      title: optional<string>
+      confidentiality: optional<code>
+      attester: optional<list<Composition_Attester>>
+      custodian: optional<Reference>
+      relatesTo: optional<list<Composition_RelatesTo>>
+      event: optional<list<Composition_Event>>
+      section: optional<list<Composition_Section>>
+  Composition_attesterMode:
+    enum:
+      - personal
+      - professional
+      - legal
+      - official
+  Composition_Attester:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Composition_attesterMode>
+      time: optional<dateTime>
+      party: optional<Reference>
+  Composition_RelatesTo:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      targetIdentifier: optional<Identifier>
+      targetReference: optional<Reference>
+  Composition_Event:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<list<CodeableConcept>>
+      period: optional<Period>
+      detail: optional<list<Reference>>
+  Composition_Section:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      title: optional<string>
+      code: optional<CodeableConcept>
+      author: optional<list<Reference>>
+      focus: optional<Reference>
+      text: optional<Narrative>
+      mode: optional<code>
+      orderedBy: optional<CodeableConcept>
+      entry: optional<list<Reference>>
+      emptyReason: optional<CodeableConcept>
+      section: optional<list<Composition_Section>>
+  ConceptmapStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ConceptMap:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<Identifier>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<ConceptmapStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      sourceUri: optional<string>
+      sourceCanonical: optional<string>
+      targetUri: optional<string>
+      targetCanonical: optional<string>
+      group: optional<list<ConceptMap_Group>>
+  ConceptMap_Group:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      source: optional<uri>
+      sourceVersion: optional<string>
+      target: optional<uri>
+      targetVersion: optional<string>
+      element: list<ConceptMap_Element>
+      unmapped: optional<ConceptMap_Unmapped>
+  ConceptMap_Element:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      display: optional<string>
+      target: optional<list<ConceptMap_Target>>
+  Conceptmap_targetEquivalence:
+    enum:
+      - relatedto
+      - equivalent
+      - equal
+      - wider
+      - subsumes
+      - narrower
+      - specializes
+      - inexact
+      - unmatched
+      - disjoint
+  ConceptMap_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      display: optional<string>
+      equivalence: optional<Conceptmap_targetEquivalence>
+      comment: optional<string>
+      dependsOn: optional<list<ConceptMap_DependsOn>>
+      product: optional<list<ConceptMap_DependsOn>>
+  ConceptMap_DependsOn:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      property: optional<uri>
+      system: optional<canonical>
+      value: optional<string>
+      display: optional<string>
+  Conceptmap_unmappedMode:
+    enum:
+      - provided
+      - fixed
+      # - other-map
+  ConceptMap_Unmapped:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      mode: optional<Conceptmap_unmappedMode>
+      code: optional<code>
+      display: optional<string>
+      url: optional<canonical>
+  Condition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      clinicalStatus: optional<CodeableConcept>
+      verificationStatus: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      severity: optional<CodeableConcept>
+      code: optional<CodeableConcept>
+      bodySite: optional<list<CodeableConcept>>
+      subject: Reference
+      encounter: optional<Reference>
+      onsetDateTime: optional<string>
+      onsetAge: optional<Age>
+      onsetPeriod: optional<Period>
+      onsetRange: optional<Range>
+      onsetString: optional<string>
+      abatementDateTime: optional<string>
+      abatementAge: optional<Age>
+      abatementPeriod: optional<Period>
+      abatementRange: optional<Range>
+      abatementString: optional<string>
+      recordedDate: optional<dateTime>
+      recorder: optional<Reference>
+      asserter: optional<Reference>
+      stage: optional<list<Condition_Stage>>
+      evidence: optional<list<Condition_Evidence>>
+      note: optional<list<Annotation>>
+  Condition_Stage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      summary: optional<CodeableConcept>
+      assessment: optional<list<Reference>>
+      type: optional<CodeableConcept>
+  Condition_Evidence:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<list<CodeableConcept>>
+      detail: optional<list<Reference>>
+  ConsentStatus:
+    enum:
+      - draft
+      - proposed
+      - active
+      - rejected
+      - inactive
+      # - entered-in-error
+  Consent:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<ConsentStatus>
+      scope: CodeableConcept
+      category: list<CodeableConcept>
+      patient: optional<Reference>
+      dateTime: optional<dateTime>
+      performer: optional<list<Reference>>
+      organization: optional<list<Reference>>
+      sourceAttachment: optional<Attachment>
+      sourceReference: optional<Reference>
+      policy: optional<list<Consent_Policy>>
+      policyRule: optional<CodeableConcept>
+      verification: optional<list<Consent_Verification>>
+      provision: optional<Consent_Provision>
+  Consent_Policy:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      authority: optional<uri>
+      uri: optional<uri>
+  Consent_Verification:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      verified: optional<boolean>
+      verifiedWith: optional<Reference>
+      verificationDate: optional<dateTime>
+  Consent_provisionType:
+    enum:
+      - deny
+      - permit
+  Consent_Provision:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Consent_provisionType>
+      period: optional<Period>
+      actor: optional<list<Consent_Actor>>
+      action: optional<list<CodeableConcept>>
+      securityLabel: optional<list<Coding>>
+      purpose: optional<list<Coding>>
+      class: optional<list<Coding>>
+      code: optional<list<CodeableConcept>>
+      dataPeriod: optional<Period>
+      data: optional<list<Consent_Data>>
+      provision: optional<list<Consent_Provision>>
+  Consent_Actor:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      role: CodeableConcept
+      reference: Reference
+  Consent_dataMeaning:
+    enum:
+      - instance
+      - related
+      - dependents
+      - authoredby
+  Consent_Data:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      meaning: optional<Consent_dataMeaning>
+      reference: Reference
+  Contract:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      url: optional<uri>
+      version: optional<string>
+      status: optional<code>
+      legalState: optional<CodeableConcept>
+      instantiatesCanonical: optional<Reference>
+      instantiatesUri: optional<uri>
+      contentDerivative: optional<CodeableConcept>
+      issued: optional<dateTime>
+      applies: optional<Period>
+      expirationType: optional<CodeableConcept>
+      subject: optional<list<Reference>>
+      authority: optional<list<Reference>>
+      domain: optional<list<Reference>>
+      site: optional<list<Reference>>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      alias: optional<list<string>>
+      author: optional<Reference>
+      scope: optional<CodeableConcept>
+      topicCodeableConcept: optional<CodeableConcept>
+      topicReference: optional<Reference>
+      type: optional<CodeableConcept>
+      subType: optional<list<CodeableConcept>>
+      contentDefinition: optional<Contract_ContentDefinition>
+      term: optional<list<Contract_Term>>
+      supportingInfo: optional<list<Reference>>
+      relevantHistory: optional<list<Reference>>
+      signer: optional<list<Contract_Signer>>
+      friendly: optional<list<Contract_Friendly>>
+      legal: optional<list<Contract_Legal>>
+      rule: optional<list<Contract_Rule>>
+      legallyBindingAttachment: optional<Attachment>
+      legallyBindingReference: optional<Reference>
+  Contract_ContentDefinition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      subType: optional<CodeableConcept>
+      publisher: optional<Reference>
+      publicationDate: optional<dateTime>
+      publicationStatus: optional<code>
+      copyright: optional<markdown>
+  Contract_Term:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      issued: optional<dateTime>
+      applies: optional<Period>
+      topicCodeableConcept: optional<CodeableConcept>
+      topicReference: optional<Reference>
+      type: optional<CodeableConcept>
+      subType: optional<CodeableConcept>
+      text: optional<string>
+      securityLabel: optional<list<Contract_SecurityLabel>>
+      offer: Contract_Offer
+      asset: optional<list<Contract_Asset>>
+      action: optional<list<Contract_Action>>
+      group: optional<list<Contract_Term>>
+  Contract_SecurityLabel:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      number: optional<list<unsignedInt>>
+      classification: Coding
+      category: optional<list<Coding>>
+      control: optional<list<Coding>>
+  Contract_Offer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      party: optional<list<Contract_Party>>
+      topic: optional<Reference>
+      type: optional<CodeableConcept>
+      decision: optional<CodeableConcept>
+      decisionMode: optional<list<CodeableConcept>>
+      answer: optional<list<Contract_Answer>>
+      text: optional<string>
+      linkId: optional<list<string>>
+      securityLabelNumber: optional<list<unsignedInt>>
+  Contract_Party:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      reference: list<Reference>
+      role: CodeableConcept
+  Contract_Answer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      valueBoolean: optional<boolean>
+      valueDecimal: optional<double>
+      valueInteger: optional<double>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueTime: optional<string>
+      valueString: optional<string>
+      valueUri: optional<string>
+      valueAttachment: optional<Attachment>
+      valueCoding: optional<Coding>
+      valueQuantity: optional<Quantity>
+      valueReference: optional<Reference>
+  Contract_Asset:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      scope: optional<CodeableConcept>
+      type: optional<list<CodeableConcept>>
+      typeReference: optional<list<Reference>>
+      subtype: optional<list<CodeableConcept>>
+      relationship: optional<Coding>
+      context: optional<list<Contract_Context>>
+      condition: optional<string>
+      periodType: optional<list<CodeableConcept>>
+      period: optional<list<Period>>
+      usePeriod: optional<list<Period>>
+      text: optional<string>
+      linkId: optional<list<string>>
+      answer: optional<list<Contract_Answer>>
+      securityLabelNumber: optional<list<unsignedInt>>
+      valuedItem: optional<list<Contract_ValuedItem>>
+  Contract_Context:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      reference: optional<Reference>
+      code: optional<list<CodeableConcept>>
+      text: optional<string>
+  Contract_ValuedItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      entityCodeableConcept: optional<CodeableConcept>
+      entityReference: optional<Reference>
+      identifier: optional<Identifier>
+      effectiveTime: optional<dateTime>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      points: optional<decimal>
+      net: optional<Money>
+      payment: optional<string>
+      paymentDate: optional<dateTime>
+      responsible: optional<Reference>
+      recipient: optional<Reference>
+      linkId: optional<list<string>>
+      securityLabelNumber: optional<list<unsignedInt>>
+  Contract_Action:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      doNotPerform: optional<boolean>
+      type: CodeableConcept
+      subject: optional<list<Contract_Subject>>
+      intent: CodeableConcept
+      linkId: optional<list<string>>
+      status: CodeableConcept
+      context: optional<Reference>
+      contextLinkId: optional<list<string>>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      requester: optional<list<Reference>>
+      requesterLinkId: optional<list<string>>
+      performerType: optional<list<CodeableConcept>>
+      performerRole: optional<CodeableConcept>
+      performer: optional<Reference>
+      performerLinkId: optional<list<string>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      reason: optional<list<string>>
+      reasonLinkId: optional<list<string>>
+      note: optional<list<Annotation>>
+      securityLabelNumber: optional<list<unsignedInt>>
+  Contract_Subject:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      reference: list<Reference>
+      role: optional<CodeableConcept>
+  Contract_Signer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: Coding
+      party: Reference
+      signature: list<Signature>
+  Contract_Friendly:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      contentAttachment: optional<Attachment>
+      contentReference: optional<Reference>
+  Contract_Legal:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      contentAttachment: optional<Attachment>
+      contentReference: optional<Reference>
+  Contract_Rule:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      contentAttachment: optional<Attachment>
+      contentReference: optional<Reference>
+  Coverage:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      type: optional<CodeableConcept>
+      policyHolder: optional<Reference>
+      subscriber: optional<Reference>
+      subscriberId: optional<string>
+      beneficiary: Reference
+      dependent: optional<string>
+      relationship: optional<CodeableConcept>
+      period: optional<Period>
+      payor: list<Reference>
+      class: optional<list<Coverage_Class>>
+      order: optional<positiveInt>
+      network: optional<string>
+      costToBeneficiary: optional<list<Coverage_CostToBeneficiary>>
+      subrogation: optional<boolean>
+      contract: optional<list<Reference>>
+  Coverage_Class:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      value: optional<string>
+      name: optional<string>
+  Coverage_CostToBeneficiary:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      valueQuantity: optional<Quantity>
+      valueMoney: optional<Money>
+      exception: optional<list<Coverage_Exception>>
+  Coverage_Exception:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      period: optional<Period>
+  CoverageeligibilityrequestPurposeItem:
+    enum:
+      # - auth-requirements
+      - benefits
+      - discovery
+      - validation
+  CoverageEligibilityRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      priority: optional<CodeableConcept>
+      purpose: optional<list<CoverageeligibilityrequestPurposeItem>>
+      patient: Reference
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      created: optional<dateTime>
+      enterer: optional<Reference>
+      provider: optional<Reference>
+      insurer: Reference
+      facility: optional<Reference>
+      supportingInfo: optional<list<CoverageEligibilityRequest_SupportingInfo>>
+      insurance: optional<list<CoverageEligibilityRequest_Insurance>>
+      item: optional<list<CoverageEligibilityRequest_Item>>
+  CoverageEligibilityRequest_SupportingInfo:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      information: Reference
+      appliesToAll: optional<boolean>
+  CoverageEligibilityRequest_Insurance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      focal: optional<boolean>
+      coverage: Reference
+      businessArrangement: optional<string>
+  CoverageEligibilityRequest_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      supportingInfoSequence: optional<list<positiveInt>>
+      category: optional<CodeableConcept>
+      productOrService: optional<CodeableConcept>
+      modifier: optional<list<CodeableConcept>>
+      provider: optional<Reference>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      facility: optional<Reference>
+      diagnosis: optional<list<CoverageEligibilityRequest_Diagnosis>>
+      detail: optional<list<Reference>>
+  CoverageEligibilityRequest_Diagnosis:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      diagnosisCodeableConcept: optional<CodeableConcept>
+      diagnosisReference: optional<Reference>
+  CoverageeligibilityresponsePurposeItem:
+    enum:
+      # - auth-requirements
+      - benefits
+      - discovery
+      - validation
+  CoverageeligibilityresponseOutcome:
+    enum:
+      - queued
+      - complete
+      - error
+      - partial
+  CoverageEligibilityResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      purpose: optional<list<CoverageeligibilityresponsePurposeItem>>
+      patient: Reference
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      created: optional<dateTime>
+      requestor: optional<Reference>
+      request: Reference
+      outcome: optional<CoverageeligibilityresponseOutcome>
+      disposition: optional<string>
+      insurer: Reference
+      insurance: optional<list<CoverageEligibilityResponse_Insurance>>
+      preAuthRef: optional<string>
+      form: optional<CodeableConcept>
+      error: optional<list<CoverageEligibilityResponse_Error>>
+  CoverageEligibilityResponse_Insurance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      coverage: Reference
+      inforce: optional<boolean>
+      benefitPeriod: optional<Period>
+      item: optional<list<CoverageEligibilityResponse_Item>>
+  CoverageEligibilityResponse_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: optional<CodeableConcept>
+      productOrService: optional<CodeableConcept>
+      modifier: optional<list<CodeableConcept>>
+      provider: optional<Reference>
+      excluded: optional<boolean>
+      name: optional<string>
+      description: optional<string>
+      network: optional<CodeableConcept>
+      unit: optional<CodeableConcept>
+      term: optional<CodeableConcept>
+      benefit: optional<list<CoverageEligibilityResponse_Benefit>>
+      authorizationRequired: optional<boolean>
+      authorizationSupporting: optional<list<CodeableConcept>>
+      authorizationUrl: optional<uri>
+  CoverageEligibilityResponse_Benefit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      allowedUnsignedInt: optional<double>
+      allowedString: optional<string>
+      allowedMoney: optional<Money>
+      usedUnsignedInt: optional<double>
+      usedString: optional<string>
+      usedMoney: optional<Money>
+  CoverageEligibilityResponse_Error:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+  DetectedissueSeverity:
+    enum:
+      - high
+      - moderate
+      - low
+  DetectedIssue:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      code: optional<CodeableConcept>
+      severity: optional<DetectedissueSeverity>
+      patient: optional<Reference>
+      identifiedDateTime: optional<string>
+      identifiedPeriod: optional<Period>
+      author: optional<Reference>
+      implicated: optional<list<Reference>>
+      evidence: optional<list<DetectedIssue_Evidence>>
+      detail: optional<string>
+      reference: optional<uri>
+      mitigation: optional<list<DetectedIssue_Mitigation>>
+  DetectedIssue_Evidence:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<list<CodeableConcept>>
+      detail: optional<list<Reference>>
+  DetectedIssue_Mitigation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: CodeableConcept
+      date: optional<dateTime>
+      author: optional<Reference>
+  DeviceStatus:
+    enum:
+      - active
+      - inactive
+      # - entered-in-error
+      - unknown
+  Device:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      definition: optional<Reference>
+      udiCarrier: optional<list<Device_UdiCarrier>>
+      status: optional<DeviceStatus>
+      statusReason: optional<list<CodeableConcept>>
+      distinctIdentifier: optional<string>
+      manufacturer: optional<string>
+      manufactureDate: optional<dateTime>
+      expirationDate: optional<dateTime>
+      lotNumber: optional<string>
+      serialNumber: optional<string>
+      deviceName: optional<list<Device_DeviceName>>
+      modelNumber: optional<string>
+      partNumber: optional<string>
+      type: optional<CodeableConcept>
+      specialization: optional<list<Device_Specialization>>
+      version: optional<list<Device_Version>>
+      property: optional<list<Device_Property>>
+      patient: optional<Reference>
+      owner: optional<Reference>
+      contact: optional<list<ContactPoint>>
+      location: optional<Reference>
+      url: optional<uri>
+      note: optional<list<Annotation>>
+      safety: optional<list<CodeableConcept>>
+      parent: optional<Reference>
+  Device_udicarrierEntrytype:
+    enum:
+      - barcode
+      - rfid
+      - manual
+      - card
+      # - self-reported
+      - unknown
+  Device_UdiCarrier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      deviceIdentifier: optional<string>
+      issuer: optional<uri>
+      jurisdiction: optional<uri>
+      carrierAIDC: optional<base64Binary>
+      carrierHRF: optional<string>
+      entryType: optional<Device_udicarrierEntrytype>
+  Device_devicenameType:
+    enum:
+      # - udi-label-name
+      # - user-friendly-name
+      # - patient-reported-name
+      # - manufacturer-name
+      # - model-name
+      - other
+  Device_DeviceName:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      type: optional<Device_devicenameType>
+  Device_Specialization:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      systemType: CodeableConcept
+      version: optional<string>
+  Device_Version:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      component: optional<Identifier>
+      value: optional<string>
+  Device_Property:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      valueQuantity: optional<list<Quantity>>
+      valueCode: optional<list<CodeableConcept>>
+  DeviceDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      udiDeviceIdentifier: optional<list<DeviceDefinition_UdiDeviceIdentifier>>
+      manufacturerString: optional<string>
+      manufacturerReference: optional<Reference>
+      deviceName: optional<list<DeviceDefinition_DeviceName>>
+      modelNumber: optional<string>
+      type: optional<CodeableConcept>
+      specialization: optional<list<DeviceDefinition_Specialization>>
+      version: optional<list<string>>
+      safety: optional<list<CodeableConcept>>
+      shelfLifeStorage: optional<list<ProductShelfLife>>
+      physicalCharacteristics: optional<ProdCharacteristic>
+      languageCode: optional<list<CodeableConcept>>
+      capability: optional<list<DeviceDefinition_Capability>>
+      property: optional<list<DeviceDefinition_Property>>
+      owner: optional<Reference>
+      contact: optional<list<ContactPoint>>
+      url: optional<uri>
+      onlineInformation: optional<uri>
+      note: optional<list<Annotation>>
+      quantity: optional<Quantity>
+      parentDevice: optional<Reference>
+      material: optional<list<DeviceDefinition_Material>>
+  DeviceDefinition_UdiDeviceIdentifier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      deviceIdentifier: optional<string>
+      issuer: optional<uri>
+      jurisdiction: optional<uri>
+  Devicedefinition_devicenameType:
+    enum:
+      # - udi-label-name
+      # - user-friendly-name
+      # - patient-reported-name
+      # - manufacturer-name
+      # - model-name
+      - other
+  DeviceDefinition_DeviceName:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      type: optional<Devicedefinition_devicenameType>
+  DeviceDefinition_Specialization:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      systemType: optional<string>
+      version: optional<string>
+  DeviceDefinition_Capability:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      description: optional<list<CodeableConcept>>
+  DeviceDefinition_Property:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      valueQuantity: optional<list<Quantity>>
+      valueCode: optional<list<CodeableConcept>>
+  DeviceDefinition_Material:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      substance: CodeableConcept
+      alternate: optional<boolean>
+      allergenicIndicator: optional<boolean>
+  DevicemetricOperationalstatus:
+    enum:
+      - "on"
+      - "off"
+      - standby
+      # - entered-in-error
+  DevicemetricColor:
+    enum:
+      - black
+      - red
+      - green
+      - yellow
+      - blue
+      - magenta
+      - cyan
+      - white
+  DevicemetricCategory:
+    enum:
+      - measurement
+      - setting
+      - calculation
+      - unspecified
+  DeviceMetric:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: CodeableConcept
+      unit: optional<CodeableConcept>
+      source: optional<Reference>
+      parent: optional<Reference>
+      operationalStatus: optional<DevicemetricOperationalstatus>
+      color: optional<DevicemetricColor>
+      category: optional<DevicemetricCategory>
+      measurementPeriod: optional<Timing>
+      calibration: optional<list<DeviceMetric_Calibration>>
+  Devicemetric_calibrationType:
+    enum:
+      - unspecified
+      - offset
+      - gain
+      # - two-point
+  Devicemetric_calibrationState:
+    enum:
+      # - not-calibrated
+      # - calibration-required
+      - calibrated
+      - unspecified
+  DeviceMetric_Calibration:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Devicemetric_calibrationType>
+      state: optional<Devicemetric_calibrationState>
+      time: optional<instant>
+  DeviceRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      priorRequest: optional<list<Reference>>
+      groupIdentifier: optional<Identifier>
+      status: optional<code>
+      intent: optional<code>
+      priority: optional<code>
+      codeReference: optional<Reference>
+      codeCodeableConcept: optional<CodeableConcept>
+      parameter: optional<list<DeviceRequest_Parameter>>
+      subject: Reference
+      encounter: optional<Reference>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      authoredOn: optional<dateTime>
+      requester: optional<Reference>
+      performerType: optional<CodeableConcept>
+      performer: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      insurance: optional<list<Reference>>
+      supportingInfo: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      relevantHistory: optional<list<Reference>>
+  DeviceRequest_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueBoolean: optional<boolean>
+  DeviceusestatementStatus:
+    enum:
+      - active
+      - completed
+      # - entered-in-error
+      - intended
+      - stopped
+      - on-hold
+  DeviceUseStatement:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      status: optional<DeviceusestatementStatus>
+      subject: Reference
+      derivedFrom: optional<list<Reference>>
+      timingTiming: optional<Timing>
+      timingPeriod: optional<Period>
+      timingDateTime: optional<string>
+      recordedOn: optional<dateTime>
+      source: optional<Reference>
+      device: Reference
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      bodySite: optional<CodeableConcept>
+      note: optional<list<Annotation>>
+  DiagnosticreportStatus:
+    enum:
+      - registered
+      - partial
+      - preliminary
+      - final
+      - amended
+      - corrected
+      - appended
+      - cancelled
+      # - entered-in-error
+      - unknown
+  DiagnosticReport:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      status: optional<DiagnosticreportStatus>
+      category: optional<list<CodeableConcept>>
+      code: CodeableConcept
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      effectiveDateTime: optional<string>
+      effectivePeriod: optional<Period>
+      issued: optional<instant>
+      performer: optional<list<Reference>>
+      resultsInterpreter: optional<list<Reference>>
+      specimen: optional<list<Reference>>
+      result: optional<list<Reference>>
+      imagingStudy: optional<list<Reference>>
+      media: optional<list<DiagnosticReport_Media>>
+      conclusion: optional<string>
+      conclusionCode: optional<list<CodeableConcept>>
+      presentedForm: optional<list<Attachment>>
+  DiagnosticReport_Media:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      comment: optional<string>
+      link: Reference
+  DocumentmanifestStatus:
+    enum:
+      - current
+      - superseded
+      # - entered-in-error
+  DocumentManifest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      masterIdentifier: optional<Identifier>
+      identifier: optional<list<Identifier>>
+      status: optional<DocumentmanifestStatus>
+      type: optional<CodeableConcept>
+      subject: optional<Reference>
+      created: optional<dateTime>
+      author: optional<list<Reference>>
+      recipient: optional<list<Reference>>
+      source: optional<uri>
+      description: optional<string>
+      content: list<Reference>
+      related: optional<list<DocumentManifest_Related>>
+  DocumentManifest_Related:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      ref: optional<Reference>
+  DocumentreferenceStatus:
+    enum:
+      - current
+      - superseded
+      # - entered-in-error
+  DocumentReference:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      masterIdentifier: optional<Identifier>
+      identifier: optional<list<Identifier>>
+      status: optional<DocumentreferenceStatus>
+      docStatus: optional<code>
+      type: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      subject: optional<Reference>
+      date: optional<instant>
+      author: optional<list<Reference>>
+      authenticator: optional<Reference>
+      custodian: optional<Reference>
+      relatesTo: optional<list<DocumentReference_RelatesTo>>
+      description: optional<string>
+      securityLabel: optional<list<CodeableConcept>>
+      content: list<DocumentReference_Content>
+      context: optional<DocumentReference_Context>
+  Documentreference_relatestoCode:
+    enum:
+      - replaces
+      - transforms
+      - signs
+      - appends
+  DocumentReference_RelatesTo:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<Documentreference_relatestoCode>
+      target: Reference
+  DocumentReference_Content:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      attachment: Attachment
+      format: optional<Coding>
+  DocumentReference_Context:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      encounter: optional<list<Reference>>
+      event: optional<list<CodeableConcept>>
+      period: optional<Period>
+      facilityType: optional<CodeableConcept>
+      practiceSetting: optional<CodeableConcept>
+      sourcePatientInfo: optional<Reference>
+      related: optional<list<Reference>>
+  EffectevidencesynthesisStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  EffectEvidenceSynthesis:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<EffectevidencesynthesisStatus>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      note: optional<list<Annotation>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      synthesisType: optional<CodeableConcept>
+      studyType: optional<CodeableConcept>
+      population: Reference
+      exposure: Reference
+      exposureAlternative: Reference
+      outcome: Reference
+      sampleSize: optional<EffectEvidenceSynthesis_SampleSize>
+      resultsByExposure: optional<list<EffectEvidenceSynthesis_ResultsByExposure>>
+      effectEstimate: optional<list<EffectEvidenceSynthesis_EffectEstimate>>
+      certainty: optional<list<EffectEvidenceSynthesis_Certainty>>
+  EffectEvidenceSynthesis_SampleSize:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      numberOfStudies: optional<integer>
+      numberOfParticipants: optional<integer>
+  Effectevidencesynthesis_resultsbyexposureExposurestate:
+    enum:
+      - exposure
+      # - exposure-alternative
+  EffectEvidenceSynthesis_ResultsByExposure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      exposureState: optional<Effectevidencesynthesis_resultsbyexposureExposurestate>
+      variantState: optional<CodeableConcept>
+      riskEvidenceSynthesis: Reference
+  EffectEvidenceSynthesis_EffectEstimate:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      type: optional<CodeableConcept>
+      variantState: optional<CodeableConcept>
+      value: optional<decimal>
+      unitOfMeasure: optional<CodeableConcept>
+      precisionEstimate: optional<list<EffectEvidenceSynthesis_PrecisionEstimate>>
+  EffectEvidenceSynthesis_PrecisionEstimate:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      level: optional<decimal>
+      from: optional<decimal>
+      to: optional<decimal>
+  EffectEvidenceSynthesis_Certainty:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      rating: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+      certaintySubcomponent: optional<list<EffectEvidenceSynthesis_CertaintySubcomponent>>
+  EffectEvidenceSynthesis_CertaintySubcomponent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      rating: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+  EncounterStatus:
+    enum:
+      - planned
+      - arrived
+      - triaged
+      # - in-progress
+      - onleave
+      - finished
+      - cancelled
+      # - entered-in-error
+      - unknown
+  Encounter:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<EncounterStatus>
+      statusHistory: optional<list<Encounter_StatusHistory>>
+      class: Coding
+      classHistory: optional<list<Encounter_ClassHistory>>
+      type: optional<list<CodeableConcept>>
+      serviceType: optional<CodeableConcept>
+      priority: optional<CodeableConcept>
+      subject: optional<Reference>
+      episodeOfCare: optional<list<Reference>>
+      basedOn: optional<list<Reference>>
+      participant: optional<list<Encounter_Participant>>
+      appointment: optional<list<Reference>>
+      period: optional<Period>
+      length: optional<Duration>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      diagnosis: optional<list<Encounter_Diagnosis>>
+      account: optional<list<Reference>>
+      hospitalization: optional<Encounter_Hospitalization>
+      location: optional<list<Encounter_Location>>
+      serviceProvider: optional<Reference>
+      partOf: optional<Reference>
+  Encounter_statushistoryStatus:
+    enum:
+      - planned
+      - arrived
+      - triaged
+      # - in-progress
+      - onleave
+      - finished
+      - cancelled
+      # - entered-in-error
+      - unknown
+  Encounter_StatusHistory:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      status: optional<Encounter_statushistoryStatus>
+      period: Period
+  Encounter_ClassHistory:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      class: Coding
+      period: Period
+  Encounter_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<list<CodeableConcept>>
+      period: optional<Period>
+      individual: optional<Reference>
+  Encounter_Diagnosis:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      condition: Reference
+      use: optional<CodeableConcept>
+      rank: optional<positiveInt>
+  Encounter_Hospitalization:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      preAdmissionIdentifier: optional<Identifier>
+      origin: optional<Reference>
+      admitSource: optional<CodeableConcept>
+      reAdmission: optional<CodeableConcept>
+      dietPreference: optional<list<CodeableConcept>>
+      specialCourtesy: optional<list<CodeableConcept>>
+      specialArrangement: optional<list<CodeableConcept>>
+      destination: optional<Reference>
+      dischargeDisposition: optional<CodeableConcept>
+  Encounter_locationStatus:
+    enum:
+      - planned
+      - active
+      - reserved
+      - completed
+  Encounter_Location:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      location: Reference
+      status: optional<Encounter_locationStatus>
+      physicalType: optional<CodeableConcept>
+      period: optional<Period>
+  EndpointStatus:
+    enum:
+      - active
+      - suspended
+      - error
+      - "off"
+      # - entered-in-error
+      - test
+  Endpoint:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<EndpointStatus>
+      connectionType: Coding
+      name: optional<string>
+      managingOrganization: optional<Reference>
+      contact: optional<list<ContactPoint>>
+      period: optional<Period>
+      payloadType: list<CodeableConcept>
+      payloadMimeType: optional<list<code>>
+      address: optional<url>
+      header: optional<list<string>>
+  EnrollmentRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      created: optional<dateTime>
+      insurer: optional<Reference>
+      provider: optional<Reference>
+      candidate: optional<Reference>
+      coverage: optional<Reference>
+  EnrollmentresponseOutcome:
+    enum:
+      - queued
+      - complete
+      - error
+      - partial
+  EnrollmentResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      request: optional<Reference>
+      outcome: optional<EnrollmentresponseOutcome>
+      disposition: optional<string>
+      created: optional<dateTime>
+      organization: optional<Reference>
+      requestProvider: optional<Reference>
+  EpisodeofcareStatus:
+    enum:
+      - planned
+      - waitlist
+      - active
+      - onhold
+      - finished
+      - cancelled
+      # - entered-in-error
+  EpisodeOfCare:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<EpisodeofcareStatus>
+      statusHistory: optional<list<EpisodeOfCare_StatusHistory>>
+      type: optional<list<CodeableConcept>>
+      diagnosis: optional<list<EpisodeOfCare_Diagnosis>>
+      patient: Reference
+      managingOrganization: optional<Reference>
+      period: optional<Period>
+      referralRequest: optional<list<Reference>>
+      careManager: optional<Reference>
+      team: optional<list<Reference>>
+      account: optional<list<Reference>>
+  Episodeofcare_statushistoryStatus:
+    enum:
+      - planned
+      - waitlist
+      - active
+      - onhold
+      - finished
+      - cancelled
+      # - entered-in-error
+  EpisodeOfCare_StatusHistory:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      status: optional<Episodeofcare_statushistoryStatus>
+      period: Period
+  EpisodeOfCare_Diagnosis:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      condition: Reference
+      role: optional<CodeableConcept>
+      rank: optional<positiveInt>
+  EventdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  EventDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      status: optional<EventdefinitionStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      trigger: list<TriggerDefinition>
+  EvidenceStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  Evidence:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      shortTitle: optional<string>
+      subtitle: optional<string>
+      status: optional<EvidenceStatus>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      note: optional<list<Annotation>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      exposureBackground: Reference
+      exposureVariant: optional<list<Reference>>
+      outcome: optional<list<Reference>>
+  EvidencevariableStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  EvidencevariableType:
+    enum:
+      - dichotomous
+      - continuous
+      - descriptive
+  EvidenceVariable:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      shortTitle: optional<string>
+      subtitle: optional<string>
+      status: optional<EvidencevariableStatus>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      note: optional<list<Annotation>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      type: optional<EvidencevariableType>
+      characteristic: list<EvidenceVariable_Characteristic>
+  Evidencevariable_characteristicGroupmeasure:
+    enum:
+      - mean
+      - median
+      # - mean-of-mean
+      # - mean-of-median
+      # - median-of-mean
+      # - median-of-median
+  EvidenceVariable_Characteristic:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      definitionReference: optional<Reference>
+      definitionCanonical: optional<string>
+      definitionCodeableConcept: optional<CodeableConcept>
+      definitionExpression: optional<Expression>
+      definitionDataRequirement: optional<DataRequirement>
+      definitionTriggerDefinition: optional<TriggerDefinition>
+      usageContext: optional<list<UsageContext>>
+      exclude: optional<boolean>
+      participantEffectiveDateTime: optional<string>
+      participantEffectivePeriod: optional<Period>
+      participantEffectiveDuration: optional<Duration>
+      participantEffectiveTiming: optional<Timing>
+      timeFromStart: optional<Duration>
+      groupMeasure: optional<Evidencevariable_characteristicGroupmeasure>
+  ExamplescenarioStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ExampleScenario:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      status: optional<ExamplescenarioStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      purpose: optional<markdown>
+      actor: optional<list<ExampleScenario_Actor>>
+      instance: optional<list<ExampleScenario_Instance>>
+      process: optional<list<ExampleScenario_Process>>
+      workflow: optional<list<canonical>>
+  Examplescenario_actorType:
+    enum:
+      - person
+      - entity
+  ExampleScenario_Actor:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      actorId: optional<string>
+      type: optional<Examplescenario_actorType>
+      name: optional<string>
+      description: optional<markdown>
+  ExampleScenario_Instance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      resourceId: optional<string>
+      resourceType: optional<code>
+      name: optional<string>
+      description: optional<markdown>
+      version: optional<list<ExampleScenario_Version>>
+      containedInstance: optional<list<ExampleScenario_ContainedInstance>>
+  ExampleScenario_Version:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      versionId: optional<string>
+      description: optional<markdown>
+  ExampleScenario_ContainedInstance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      resourceId: optional<string>
+      versionId: optional<string>
+  ExampleScenario_Process:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      title: optional<string>
+      description: optional<markdown>
+      preConditions: optional<markdown>
+      postConditions: optional<markdown>
+      step: optional<list<ExampleScenario_Step>>
+  ExampleScenario_Step:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      process: optional<list<ExampleScenario_Process>>
+      pause: optional<boolean>
+      operation: optional<ExampleScenario_Operation>
+      alternative: optional<list<ExampleScenario_Alternative>>
+  ExampleScenario_Operation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      number: optional<string>
+      type: optional<string>
+      name: optional<string>
+      initiator: optional<string>
+      receiver: optional<string>
+      description: optional<markdown>
+      initiatorActive: optional<boolean>
+      receiverActive: optional<boolean>
+      request: optional<ExampleScenario_ContainedInstance>
+      response: optional<ExampleScenario_ContainedInstance>
+  ExampleScenario_Alternative:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      title: optional<string>
+      description: optional<markdown>
+      step: optional<list<ExampleScenario_Step>>
+  ExplanationofbenefitStatus:
+    enum:
+      - active
+      - cancelled
+      - draft
+      # - entered-in-error
+  ExplanationOfBenefit:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<ExplanationofbenefitStatus>
+      type: CodeableConcept
+      subType: optional<CodeableConcept>
+      use: optional<code>
+      patient: Reference
+      billablePeriod: optional<Period>
+      created: optional<dateTime>
+      enterer: optional<Reference>
+      insurer: Reference
+      provider: Reference
+      priority: optional<CodeableConcept>
+      fundsReserveRequested: optional<CodeableConcept>
+      fundsReserve: optional<CodeableConcept>
+      related: optional<list<ExplanationOfBenefit_Related>>
+      prescription: optional<Reference>
+      originalPrescription: optional<Reference>
+      payee: optional<ExplanationOfBenefit_Payee>
+      referral: optional<Reference>
+      facility: optional<Reference>
+      claim: optional<Reference>
+      claimResponse: optional<Reference>
+      outcome: optional<code>
+      disposition: optional<string>
+      preAuthRef: optional<list<string>>
+      preAuthRefPeriod: optional<list<Period>>
+      careTeam: optional<list<ExplanationOfBenefit_CareTeam>>
+      supportingInfo: optional<list<ExplanationOfBenefit_SupportingInfo>>
+      diagnosis: optional<list<ExplanationOfBenefit_Diagnosis>>
+      procedure: optional<list<ExplanationOfBenefit_Procedure>>
+      precedence: optional<positiveInt>
+      insurance: list<ExplanationOfBenefit_Insurance>
+      accident: optional<ExplanationOfBenefit_Accident>
+      item: optional<list<ExplanationOfBenefit_Item>>
+      addItem: optional<list<ExplanationOfBenefit_AddItem>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+      total: optional<list<ExplanationOfBenefit_Total>>
+      payment: optional<ExplanationOfBenefit_Payment>
+      formCode: optional<CodeableConcept>
+      form: optional<Attachment>
+      processNote: optional<list<ExplanationOfBenefit_ProcessNote>>
+      benefitPeriod: optional<Period>
+      benefitBalance: optional<list<ExplanationOfBenefit_BenefitBalance>>
+  ExplanationOfBenefit_Related:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      claim: optional<Reference>
+      relationship: optional<CodeableConcept>
+      reference: optional<Identifier>
+  ExplanationOfBenefit_Payee:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      party: optional<Reference>
+  ExplanationOfBenefit_CareTeam:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      provider: Reference
+      responsible: optional<boolean>
+      role: optional<CodeableConcept>
+      qualification: optional<CodeableConcept>
+  ExplanationOfBenefit_SupportingInfo:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      category: CodeableConcept
+      code: optional<CodeableConcept>
+      timingDate: optional<string>
+      timingPeriod: optional<Period>
+      valueBoolean: optional<boolean>
+      valueString: optional<string>
+      valueQuantity: optional<Quantity>
+      valueAttachment: optional<Attachment>
+      valueReference: optional<Reference>
+      reason: optional<Coding>
+  ExplanationOfBenefit_Diagnosis:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      diagnosisCodeableConcept: optional<CodeableConcept>
+      diagnosisReference: optional<Reference>
+      type: optional<list<CodeableConcept>>
+      onAdmission: optional<CodeableConcept>
+      packageCode: optional<CodeableConcept>
+  ExplanationOfBenefit_Procedure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      type: optional<list<CodeableConcept>>
+      date: optional<dateTime>
+      procedureCodeableConcept: optional<CodeableConcept>
+      procedureReference: optional<Reference>
+      udi: optional<list<Reference>>
+  ExplanationOfBenefit_Insurance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      focal: optional<boolean>
+      coverage: Reference
+      preAuthRef: optional<list<string>>
+  ExplanationOfBenefit_Accident:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      date: optional<date>
+      type: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+  ExplanationOfBenefit_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      careTeamSequence: optional<list<positiveInt>>
+      diagnosisSequence: optional<list<positiveInt>>
+      procedureSequence: optional<list<positiveInt>>
+      informationSequence: optional<list<positiveInt>>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      locationCodeableConcept: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+      bodySite: optional<CodeableConcept>
+      subSite: optional<list<CodeableConcept>>
+      encounter: optional<list<Reference>>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+      detail: optional<list<ExplanationOfBenefit_Detail>>
+  ExplanationOfBenefit_Adjudication:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      reason: optional<CodeableConcept>
+      amount: optional<Money>
+      value: optional<decimal>
+  ExplanationOfBenefit_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+      subDetail: optional<list<ExplanationOfBenefit_SubDetail>>
+  ExplanationOfBenefit_SubDetail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      revenue: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      udi: optional<list<Reference>>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+  ExplanationOfBenefit_AddItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemSequence: optional<list<positiveInt>>
+      detailSequence: optional<list<positiveInt>>
+      subDetailSequence: optional<list<positiveInt>>
+      provider: optional<list<Reference>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      programCode: optional<list<CodeableConcept>>
+      servicedDate: optional<string>
+      servicedPeriod: optional<Period>
+      locationCodeableConcept: optional<CodeableConcept>
+      locationAddress: optional<Address>
+      locationReference: optional<Reference>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      bodySite: optional<CodeableConcept>
+      subSite: optional<list<CodeableConcept>>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+      detail: optional<list<ExplanationOfBenefit_Detail1>>
+  ExplanationOfBenefit_Detail1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+      subDetail: optional<list<ExplanationOfBenefit_SubDetail1>>
+  ExplanationOfBenefit_SubDetail1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      productOrService: CodeableConcept
+      modifier: optional<list<CodeableConcept>>
+      quantity: optional<Quantity>
+      unitPrice: optional<Money>
+      factor: optional<decimal>
+      net: optional<Money>
+      noteNumber: optional<list<positiveInt>>
+      adjudication: optional<list<ExplanationOfBenefit_Adjudication>>
+  ExplanationOfBenefit_Total:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      amount: Money
+  ExplanationOfBenefit_Payment:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      adjustment: optional<Money>
+      adjustmentReason: optional<CodeableConcept>
+      date: optional<date>
+      amount: optional<Money>
+      identifier: optional<Identifier>
+  Explanationofbenefit_processnoteType:
+    enum:
+      - display
+      - print
+      - printoper
+  ExplanationOfBenefit_ProcessNote:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      number: optional<positiveInt>
+      type: optional<Explanationofbenefit_processnoteType>
+      text: optional<string>
+      language: optional<CodeableConcept>
+  ExplanationOfBenefit_BenefitBalance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      excluded: optional<boolean>
+      name: optional<string>
+      description: optional<string>
+      network: optional<CodeableConcept>
+      unit: optional<CodeableConcept>
+      term: optional<CodeableConcept>
+      financial: optional<list<ExplanationOfBenefit_Financial>>
+  ExplanationOfBenefit_Financial:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      allowedUnsignedInt: optional<double>
+      allowedString: optional<string>
+      allowedMoney: optional<Money>
+      usedUnsignedInt: optional<double>
+      usedMoney: optional<Money>
+  FamilymemberhistoryStatus:
+    enum:
+      - partial
+      - completed
+      # - entered-in-error
+      # - health-unknown
+  FamilyMemberHistory:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      status: optional<FamilymemberhistoryStatus>
+      dataAbsentReason: optional<CodeableConcept>
+      patient: Reference
+      date: optional<dateTime>
+      name: optional<string>
+      relationship: CodeableConcept
+      sex: optional<CodeableConcept>
+      bornPeriod: optional<Period>
+      bornDate: optional<string>
+      bornString: optional<string>
+      ageAge: optional<Age>
+      ageRange: optional<Range>
+      ageString: optional<string>
+      estimatedAge: optional<boolean>
+      deceasedBoolean: optional<boolean>
+      deceasedAge: optional<Age>
+      deceasedRange: optional<Range>
+      deceasedDate: optional<string>
+      deceasedString: optional<string>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      condition: optional<list<FamilyMemberHistory_Condition>>
+  FamilyMemberHistory_Condition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      outcome: optional<CodeableConcept>
+      contributedToDeath: optional<boolean>
+      onsetAge: optional<Age>
+      onsetRange: optional<Range>
+      onsetPeriod: optional<Period>
+      onsetString: optional<string>
+      note: optional<list<Annotation>>
+  FlagStatus:
+    enum:
+      - active
+      - inactive
+      # - entered-in-error
+  Flag:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<FlagStatus>
+      category: optional<list<CodeableConcept>>
+      code: CodeableConcept
+      subject: Reference
+      period: optional<Period>
+      encounter: optional<Reference>
+      author: optional<Reference>
+  GoalLifecyclestatus:
+    enum:
+      - proposed
+      - planned
+      - accepted
+      - active
+      # - on-hold
+      - completed
+      - cancelled
+      # - entered-in-error
+      - rejected
+  Goal:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      lifecycleStatus: optional<GoalLifecyclestatus>
+      achievementStatus: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      priority: optional<CodeableConcept>
+      description: CodeableConcept
+      subject: Reference
+      startDate: optional<string>
+      startCodeableConcept: optional<CodeableConcept>
+      target: optional<list<Goal_Target>>
+      statusDate: optional<date>
+      statusReason: optional<string>
+      expressedBy: optional<Reference>
+      addresses: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      outcomeCode: optional<list<CodeableConcept>>
+      outcomeReference: optional<list<Reference>>
+  Goal_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      measure: optional<CodeableConcept>
+      detailQuantity: optional<Quantity>
+      detailRange: optional<Range>
+      detailCodeableConcept: optional<CodeableConcept>
+      detailString: optional<string>
+      detailBoolean: optional<boolean>
+      detailInteger: optional<double>
+      detailRatio: optional<Ratio>
+      dueDate: optional<string>
+      dueDuration: optional<Duration>
+  GraphdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  GraphDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      status: optional<GraphdefinitionStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      start: optional<code>
+      profile: optional<canonical>
+      link: optional<list<GraphDefinition_Link>>
+  GraphDefinition_Link:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      sliceName: optional<string>
+      min: optional<integer>
+      max: optional<string>
+      description: optional<string>
+      target: optional<list<GraphDefinition_Target>>
+  GraphDefinition_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<code>
+      params: optional<string>
+      profile: optional<canonical>
+      compartment: optional<list<GraphDefinition_Compartment>>
+      link: optional<list<GraphDefinition_Link>>
+  Graphdefinition_compartmentUse:
+    enum:
+      - condition
+      - requirement
+  Graphdefinition_compartmentRule:
+    enum:
+      - identical
+      - matching
+      - different
+      - custom
+  GraphDefinition_Compartment:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      use: optional<Graphdefinition_compartmentUse>
+      code: optional<code>
+      rule: optional<Graphdefinition_compartmentRule>
+      expression: optional<string>
+      description: optional<string>
+  GroupType:
+    enum:
+      - person
+      - animal
+      - practitioner
+      - device
+      - medication
+      - substance
+  Group:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      type: optional<GroupType>
+      actual: optional<boolean>
+      code: optional<CodeableConcept>
+      name: optional<string>
+      quantity: optional<unsignedInt>
+      managingEntity: optional<Reference>
+      characteristic: optional<list<Group_Characteristic>>
+      member: optional<list<Group_Member>>
+  Group_Characteristic:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      valueCodeableConcept: optional<CodeableConcept>
+      valueBoolean: optional<boolean>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueReference: optional<Reference>
+      exclude: optional<boolean>
+      period: optional<Period>
+  Group_Member:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      entity: Reference
+      period: optional<Period>
+      inactive: optional<boolean>
+  GuidanceresponseStatus:
+    enum:
+      - success
+      # - data-requested
+      # - data-required
+      # - in-progress
+      - failure
+      # - entered-in-error
+  GuidanceResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      requestIdentifier: optional<Identifier>
+      identifier: optional<list<Identifier>>
+      moduleUri: optional<string>
+      moduleCanonical: optional<string>
+      moduleCodeableConcept: optional<CodeableConcept>
+      status: optional<GuidanceresponseStatus>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      occurrenceDateTime: optional<dateTime>
+      performer: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      evaluationMessage: optional<list<Reference>>
+      outputParameters: optional<Reference>
+      result: optional<Reference>
+      dataRequirement: optional<list<DataRequirement>>
+  HealthcareService:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      providedBy: optional<Reference>
+      category: optional<list<CodeableConcept>>
+      type: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      location: optional<list<Reference>>
+      name: optional<string>
+      comment: optional<string>
+      extraDetails: optional<markdown>
+      photo: optional<Attachment>
+      telecom: optional<list<ContactPoint>>
+      coverageArea: optional<list<Reference>>
+      serviceProvisionCode: optional<list<CodeableConcept>>
+      eligibility: optional<list<HealthcareService_Eligibility>>
+      program: optional<list<CodeableConcept>>
+      characteristic: optional<list<CodeableConcept>>
+      communication: optional<list<CodeableConcept>>
+      referralMethod: optional<list<CodeableConcept>>
+      appointmentRequired: optional<boolean>
+      availableTime: optional<list<HealthcareService_AvailableTime>>
+      notAvailable: optional<list<HealthcareService_NotAvailable>>
+      availabilityExceptions: optional<string>
+      endpoint: optional<list<Reference>>
+  HealthcareService_Eligibility:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      comment: optional<markdown>
+  Healthcareservice_availabletimeDaysofweekItem:
+    enum:
+      - mon
+      - tue
+      - wed
+      - thu
+      - fri
+      - sat
+      - sun
+  HealthcareService_AvailableTime:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      daysOfWeek: optional<list<Healthcareservice_availabletimeDaysofweekItem>>
+      allDay: optional<boolean>
+      availableStartTime: optional<time>
+      availableEndTime: optional<time>
+  HealthcareService_NotAvailable:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      during: optional<Period>
+  ImagingstudyStatus:
+    enum:
+      - registered
+      - available
+      - cancelled
+      # - entered-in-error
+      - unknown
+  ImagingStudy:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<ImagingstudyStatus>
+      modality: optional<list<Coding>>
+      subject: Reference
+      encounter: optional<Reference>
+      started: optional<dateTime>
+      basedOn: optional<list<Reference>>
+      referrer: optional<Reference>
+      interpreter: optional<list<Reference>>
+      endpoint: optional<list<Reference>>
+      numberOfSeries: optional<unsignedInt>
+      numberOfInstances: optional<unsignedInt>
+      procedureReference: optional<Reference>
+      procedureCode: optional<list<CodeableConcept>>
+      location: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      description: optional<string>
+      series: optional<list<ImagingStudy_Series>>
+  ImagingStudy_Series:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      uid: optional<id>
+      number: optional<unsignedInt>
+      modality: Coding
+      description: optional<string>
+      numberOfInstances: optional<unsignedInt>
+      endpoint: optional<list<Reference>>
+      bodySite: optional<Coding>
+      laterality: optional<Coding>
+      specimen: optional<list<Reference>>
+      started: optional<dateTime>
+      performer: optional<list<ImagingStudy_Performer>>
+      instance: optional<list<ImagingStudy_Instance>>
+  ImagingStudy_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+  ImagingStudy_Instance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      uid: optional<id>
+      sopClass: Coding
+      number: optional<unsignedInt>
+      title: optional<string>
+  Immunization:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      vaccineCode: CodeableConcept
+      patient: Reference
+      encounter: optional<Reference>
+      occurrenceDateTime: optional<string>
+      occurrenceString: optional<string>
+      recorded: optional<dateTime>
+      primarySource: optional<boolean>
+      reportOrigin: optional<CodeableConcept>
+      location: optional<Reference>
+      manufacturer: optional<Reference>
+      lotNumber: optional<string>
+      expirationDate: optional<date>
+      site: optional<CodeableConcept>
+      route: optional<CodeableConcept>
+      doseQuantity: optional<Quantity>
+      performer: optional<list<Immunization_Performer>>
+      note: optional<list<Annotation>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      isSubpotent: optional<boolean>
+      subpotentReason: optional<list<CodeableConcept>>
+      education: optional<list<Immunization_Education>>
+      programEligibility: optional<list<CodeableConcept>>
+      fundingSource: optional<CodeableConcept>
+      reaction: optional<list<Immunization_Reaction>>
+      protocolApplied: optional<list<Immunization_ProtocolApplied>>
+  Immunization_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+  Immunization_Education:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      documentType: optional<string>
+      reference: optional<uri>
+      publicationDate: optional<dateTime>
+      presentationDate: optional<dateTime>
+  Immunization_Reaction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      date: optional<dateTime>
+      detail: optional<Reference>
+      reported: optional<boolean>
+  Immunization_ProtocolApplied:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      series: optional<string>
+      authority: optional<Reference>
+      targetDisease: optional<list<CodeableConcept>>
+      doseNumberPositiveInt: optional<double>
+      doseNumberString: optional<string>
+      seriesDosesPositiveInt: optional<double>
+      seriesDosesString: optional<string>
+  ImmunizationEvaluation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      patient: Reference
+      date: optional<dateTime>
+      authority: optional<Reference>
+      targetDisease: CodeableConcept
+      immunizationEvent: Reference
+      doseStatus: CodeableConcept
+      doseStatusReason: optional<list<CodeableConcept>>
+      description: optional<string>
+      series: optional<string>
+      doseNumberPositiveInt: optional<double>
+      doseNumberString: optional<string>
+      seriesDosesPositiveInt: optional<double>
+      seriesDosesString: optional<string>
+  ImmunizationRecommendation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      patient: Reference
+      date: optional<dateTime>
+      authority: optional<Reference>
+      recommendation: list<ImmunizationRecommendation_Recommendation>
+  ImmunizationRecommendation_Recommendation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      vaccineCode: optional<list<CodeableConcept>>
+      targetDisease: optional<CodeableConcept>
+      contraindicatedVaccineCode: optional<list<CodeableConcept>>
+      forecastStatus: CodeableConcept
+      forecastReason: optional<list<CodeableConcept>>
+      dateCriterion: optional<list<ImmunizationRecommendation_DateCriterion>>
+      description: optional<string>
+      series: optional<string>
+      doseNumberPositiveInt: optional<double>
+      doseNumberString: optional<string>
+      seriesDosesPositiveInt: optional<double>
+      seriesDosesString: optional<string>
+      supportingImmunization: optional<list<Reference>>
+      supportingPatientInformation: optional<list<Reference>>
+  ImmunizationRecommendation_DateCriterion:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      value: optional<dateTime>
+  ImplementationguideStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ImplementationguideLicense:
+    enum:
+      # - not-open-source
+      - 0BSD
+      - AAL
+      - Abstyles
+      # - Adobe-2006
+      # - Adobe-Glyph
+      # - ADSL
+      # - AFL-1.1
+      # - AFL-1.2
+      # - AFL-2.0
+      # - AFL-2.1
+      # - AFL-3.0
+      # - Afmparse
+      # - AGPL-1.0-only
+      # - AGPL-1.0-or-later
+      # - AGPL-3.0-only
+      # - AGPL-3.0-or-later
+      - Aladdin
+      - AMDPLPA
+      - AML
+      - AMPAS
+      # - ANTLR-PD
+      # - Apache-1.0
+      # - Apache-1.1
+      # - Apache-2.0
+      # - APAFML
+      # - APL-1.0
+      # - APSL-1.0
+      # - APSL-1.1
+      # - APSL-1.2
+      # - APSL-2.0
+      # - Artistic-1.0-cl8
+      # - Artistic-1.0-Perl
+      # - Artistic-1.0
+      # - Artistic-2.0
+      # - Bahyph
+      # - Barr
+      # - Beerware
+      # - BitTorrent-1.0
+      # - BitTorrent-1.1
+      # - Borceux
+      # - BSD-1-Clause
+      # - BSD-2-Clause-FreeBSD
+      # - BSD-2-Clause-NetBSD
+      # - BSD-2-Clause-Patent
+      # - BSD-2-Clause
+      # - BSD-3-Clause-Attribution
+      # - BSD-3-Clause-Clear
+      # - BSD-3-Clause-LBNL
+      # - BSD-3-Clause-No-Nuclear-License-2014
+      # - BSD-3-Clause-No-Nuclear-License
+      # - BSD-3-Clause-No-Nuclear-Warranty
+      # - BSD-3-Clause
+      # - BSD-4-Clause-UC
+      # - BSD-4-Clause
+      # - BSD-Protection
+      # - BSD-Source-Code
+      # - BSL-1.0
+      # - bzip2-1.0.5
+      # - bzip2-1.0.6
+      # - Caldera
+      # - CATOSL-1.1
+      # - CC-BY-1.0
+      # - CC-BY-2.0
+      # - CC-BY-2.5
+      # - CC-BY-3.0
+      # - CC-BY-4.0
+      # - CC-BY-NC-1.0
+      # - CC-BY-NC-2.0
+      # - CC-BY-NC-2.5
+      # - CC-BY-NC-3.0
+      # - CC-BY-NC-4.0
+      # - CC-BY-NC-ND-1.0
+      # - CC-BY-NC-ND-2.0
+      # - CC-BY-NC-ND-2.5
+      # - CC-BY-NC-ND-3.0
+      # - CC-BY-NC-ND-4.0
+      # - CC-BY-NC-SA-1.0
+      # - CC-BY-NC-SA-2.0
+      # - CC-BY-NC-SA-2.5
+      # - CC-BY-NC-SA-3.0
+      # - CC-BY-NC-SA-4.0
+      # - CC-BY-ND-1.0
+      # - CC-BY-ND-2.0
+      # - CC-BY-ND-2.5
+      # - CC-BY-ND-3.0
+      # - CC-BY-ND-4.0
+      # - CC-BY-SA-1.0
+      # - CC-BY-SA-2.0
+      # - CC-BY-SA-2.5
+      # - CC-BY-SA-3.0
+      # - CC-BY-SA-4.0
+      # - CC0-1.0
+      # - CDDL-1.0
+      # - CDDL-1.1
+      # - CDLA-Permissive-1.0
+      # - CDLA-Sharing-1.0
+      # - CECILL-1.0
+      # - CECILL-1.1
+      # - CECILL-2.0
+      # - CECILL-2.1
+      # - CECILL-B
+      # - CECILL-C
+      # - ClArtistic
+      # - CNRI-Jython
+      # - CNRI-Python-GPL-Compatible
+      # - CNRI-Python
+      # - Condor-1.1
+      # - CPAL-1.0
+      # - CPL-1.0
+      # - CPOL-1.02
+      # - Crossword
+      # - CrystalStacker
+      # - CUA-OPL-1.0
+      # - Cube
+      # - curl
+      # - D-FSL-1.0
+      # - diffmark
+      # - DOC
+      # - Dotseqn
+      # - DSDP
+      # - dvipdfm
+      # - ECL-1.0
+      # - ECL-2.0
+      # - EFL-1.0
+      # - EFL-2.0
+      # - eGenix
+      # - Entessa
+      # - EPL-1.0
+      # - EPL-2.0
+      # - ErlPL-1.1
+      # - EUDatagrid
+      # - EUPL-1.0
+      # - EUPL-1.1
+      # - EUPL-1.2
+      # - Eurosym
+      # - Fair
+      # - Frameworx-1.0
+      # - FreeImage
+      # - FSFAP
+      # - FSFUL
+      # - FSFULLR
+      # - FTL
+      # - GFDL-1.1-only
+      # - GFDL-1.1-or-later
+      # - GFDL-1.2-only
+      # - GFDL-1.2-or-later
+      # - GFDL-1.3-only
+      # - GFDL-1.3-or-later
+      # - Giftware
+      # - GL2PS
+      # - Glide
+      # - Glulxe
+      # - gnuplot
+      # - GPL-1.0-only
+      # - GPL-1.0-or-later
+      # - GPL-2.0-only
+      # - GPL-2.0-or-later
+      # - GPL-3.0-only
+      # - GPL-3.0-or-later
+      # - gSOAP-1.3b
+      # - HaskellReport
+      # - HPND
+      # - IBM-pibs
+      # - ICU
+      # - IJG
+      # - ImageMagick
+      # - iMatix
+      # - Imlib2
+      # - Info-ZIP
+      # - Intel-ACPI
+      # - Intel
+      # - Interbase-1.0
+      # - IPA
+      # - IPL-1.0
+      # - ISC
+      # - JasPer-2.0
+      # - JSON
+      # - LAL-1.2
+      # - LAL-1.3
+      # - Latex2e
+      # - Leptonica
+      # - LGPL-2.0-only
+      # - LGPL-2.0-or-later
+      # - LGPL-2.1-only
+      # - LGPL-2.1-or-later
+      # - LGPL-3.0-only
+      # - LGPL-3.0-or-later
+      # - LGPLLR
+      # - Libpng
+      # - libtiff
+      # - LiLiQ-P-1.1
+      # - LiLiQ-R-1.1
+      # - LiLiQ-Rplus-1.1
+      # - Linux-OpenIB
+      # - LPL-1.0
+      # - LPL-1.02
+      # - LPPL-1.0
+      # - LPPL-1.1
+      # - LPPL-1.2
+      # - LPPL-1.3a
+      # - LPPL-1.3c
+      # - MakeIndex
+      # - MirOS
+      # - MIT-0
+      # - MIT-advertising
+      # - MIT-CMU
+      # - MIT-enna
+      # - MIT-feh
+      # - MIT
+      # - MITNFA
+      # - Motosoto
+      # - mpich2
+      # - MPL-1.0
+      # - MPL-1.1
+      # - MPL-2.0-no-copyleft-exception
+      # - MPL-2.0
+      # - MS-PL
+      # - MS-RL
+      # - MTLL
+      # - Multics
+      # - Mup
+      # - NASA-1.3
+      # - Naumen
+      # - NBPL-1.0
+      # - NCSA
+      # - Net-SNMP
+      # - NetCDF
+      # - Newsletr
+      # - NGPL
+      # - NLOD-1.0
+      # - NLPL
+      # - Nokia
+      # - NOSL
+      # - Noweb
+      # - NPL-1.0
+      # - NPL-1.1
+      # - NPOSL-3.0
+      # - NRL
+      # - NTP
+      # - OCCT-PL
+      # - OCLC-2.0
+      # - ODbL-1.0
+      # - OFL-1.0
+      # - OFL-1.1
+      # - OGTSL
+      # - OLDAP-1.1
+      # - OLDAP-1.2
+      # - OLDAP-1.3
+      # - OLDAP-1.4
+      # - OLDAP-2.0.1
+      # - OLDAP-2.0
+      # - OLDAP-2.1
+      # - OLDAP-2.2.1
+      # - OLDAP-2.2.2
+      # - OLDAP-2.2
+      # - OLDAP-2.3
+      # - OLDAP-2.4
+      # - OLDAP-2.5
+      # - OLDAP-2.6
+      # - OLDAP-2.7
+      # - OLDAP-2.8
+      # - OML
+      # - OpenSSL
+      # - OPL-1.0
+      # - OSET-PL-2.1
+      # - OSL-1.0
+      # - OSL-1.1
+      # - OSL-2.0
+      # - OSL-2.1
+      # - OSL-3.0
+      # - PDDL-1.0
+      # - PHP-3.0
+      # - PHP-3.01
+      # - Plexus
+      # - PostgreSQL
+      # - psfrag
+      # - psutils
+      # - Python-2.0
+      # - Qhull
+      # - QPL-1.0
+      # - Rdisc
+      # - RHeCos-1.1
+      # - RPL-1.1
+      # - RPL-1.5
+      # - RPSL-1.0
+      # - RSA-MD
+      # - RSCPL
+      # - Ruby
+      # - SAX-PD
+      # - Saxpath
+      # - SCEA
+      # - Sendmail
+      # - SGI-B-1.0
+      # - SGI-B-1.1
+      # - SGI-B-2.0
+      # - SimPL-2.0
+      # - SISSL-1.2
+      # - SISSL
+      # - Sleepycat
+      # - SMLNJ
+      # - SMPPL
+      # - SNIA
+      # - Spencer-86
+      # - Spencer-94
+      # - Spencer-99
+      # - SPL-1.0
+      # - SugarCRM-1.1.3
+      # - SWL
+      # - TCL
+      # - TCP-wrappers
+      # - TMate
+      # - TORQUE-1.1
+      # - TOSL
+      # - Unicode-DFS-2015
+      # - Unicode-DFS-2016
+      # - Unicode-TOU
+      # - Unlicense
+      # - UPL-1.0
+      # - Vim
+      # - VOSTROM
+      # - VSL-1.0
+      # - W3C-19980720
+      # - W3C-20150513
+      # - W3C
+      # - Watcom-1.0
+      # - Wsuipa
+      # - WTFPL
+      # - X11
+      # - Xerox
+      # - XFree86-1.1
+      # - xinetd
+      # - Xnet
+      # - xpp
+      # - XSkat
+      # - YPL-1.0
+      # - YPL-1.1
+      # - Zed
+      # - Zend-2.0
+      # - Zimbra-1.3
+      # - Zimbra-1.4
+      # - zlib-acknowledgement
+      # - Zlib
+      # - ZPL-1.1
+      # - ZPL-2.0
+      # - ZPL-2.1
+  ImplementationguideFhirversionItem:
+    enum:
+      []
+      # - "0.01"
+      # - "0.05"
+      # - "0.06"
+      # - "0.11"
+      # - 0.0.80
+      # - 0.0.81
+      # - 0.0.82
+      # - 0.4.0
+      # - 0.5.0
+      # - 1.0.0
+      # - 1.0.1
+      # - 1.0.2
+      # - 1.1.0
+      # - 1.4.0
+      # - 1.6.0
+      # - 1.8.0
+      # - 3.0.0
+      # - 3.0.1
+      # - 3.3.0
+      # - 3.5.0
+      # - 4.0.0
+      # - 4.0.1
+  ImplementationGuide:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<ImplementationguideStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      packageId: optional<id>
+      license: optional<ImplementationguideLicense>
+      fhirVersion: optional<list<ImplementationguideFhirversionItem>>
+      dependsOn: optional<list<ImplementationGuide_DependsOn>>
+      global: optional<list<ImplementationGuide_Global>>
+      definition: optional<ImplementationGuide_Definition>
+      manifest: optional<ImplementationGuide_Manifest>
+  ImplementationGuide_DependsOn:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      uri: canonical
+      packageId: optional<id>
+      version: optional<string>
+  ImplementationGuide_Global:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<code>
+      profile: canonical
+  ImplementationGuide_Definition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      grouping: optional<list<ImplementationGuide_Grouping>>
+      resource: list<ImplementationGuide_Resource>
+      page: optional<ImplementationGuide_Page>
+      parameter: optional<list<ImplementationGuide_Parameter>>
+      template: optional<list<ImplementationGuide_Template>>
+  ImplementationGuide_Grouping:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      description: optional<string>
+  Implementationguide_resourceFhirversionItem:
+    enum:
+      []
+      # - "0.01"
+      # - "0.05"
+      # - "0.06"
+      # - "0.11"
+      # - 0.0.80
+      # - 0.0.81
+      # - 0.0.82
+      # - 0.4.0
+      # - 0.5.0
+      # - 1.0.0
+      # - 1.0.1
+      # - 1.0.2
+      # - 1.1.0
+      # - 1.4.0
+      # - 1.6.0
+      # - 1.8.0
+      # - 3.0.0
+      # - 3.0.1
+      # - 3.3.0
+      # - 3.5.0
+      # - 4.0.0
+      # - 4.0.1
+  ImplementationGuide_Resource:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      reference: Reference
+      fhirVersion: optional<list<Implementationguide_resourceFhirversionItem>>
+      name: optional<string>
+      description: optional<string>
+      exampleBoolean: optional<boolean>
+      exampleCanonical: optional<string>
+      groupingId: optional<id>
+  Implementationguide_pageGeneration:
+    enum:
+      - html
+      - markdown
+      - xml
+      - generated
+  ImplementationGuide_Page:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      nameUrl: optional<string>
+      nameReference: optional<Reference>
+      title: optional<string>
+      generation: optional<Implementationguide_pageGeneration>
+      page: optional<list<ImplementationGuide_Page>>
+  Implementationguide_parameterCode:
+    enum:
+      - apply
+      - path-resource
+      - path-pages
+      - path-tx-cache
+      - expansion-parameter
+      - rule-broken-links
+      - generate-xml
+      - generate-json
+      - generate-turtle
+      - html-template
+  ImplementationGuide_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<Implementationguide_parameterCode>
+      value: optional<string>
+  ImplementationGuide_Template:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      source: optional<string>
+      scope: optional<string>
+  ImplementationGuide_Manifest:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      rendering: optional<url>
+      resource: list<ImplementationGuide_Resource1>
+      page: optional<list<ImplementationGuide_Page1>>
+      image: optional<list<string>>
+      other: optional<list<string>>
+  ImplementationGuide_Resource1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      reference: Reference
+      exampleBoolean: optional<boolean>
+      exampleCanonical: optional<string>
+      relativePath: optional<url>
+  ImplementationGuide_Page1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      title: optional<string>
+      anchor: optional<list<string>>
+  InsuranceplanStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  InsurancePlan:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<InsuranceplanStatus>
+      type: optional<list<CodeableConcept>>
+      name: optional<string>
+      alias: optional<list<string>>
+      period: optional<Period>
+      ownedBy: optional<Reference>
+      administeredBy: optional<Reference>
+      coverageArea: optional<list<Reference>>
+      contact: optional<list<InsurancePlan_Contact>>
+      endpoint: optional<list<Reference>>
+      network: optional<list<Reference>>
+      coverage: optional<list<InsurancePlan_Coverage>>
+      plan: optional<list<InsurancePlan_Plan>>
+  InsurancePlan_Contact:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      purpose: optional<CodeableConcept>
+      name: optional<HumanName>
+      telecom: optional<list<ContactPoint>>
+      address: optional<Address>
+  InsurancePlan_Coverage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      network: optional<list<Reference>>
+      benefit: list<InsurancePlan_Benefit>
+  InsurancePlan_Benefit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      requirement: optional<string>
+      limit: optional<list<InsurancePlan_Limit>>
+  InsurancePlan_Limit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      value: optional<Quantity>
+      code: optional<CodeableConcept>
+  InsurancePlan_Plan:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: optional<CodeableConcept>
+      coverageArea: optional<list<Reference>>
+      network: optional<list<Reference>>
+      generalCost: optional<list<InsurancePlan_GeneralCost>>
+      specificCost: optional<list<InsurancePlan_SpecificCost>>
+  InsurancePlan_GeneralCost:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      groupSize: optional<positiveInt>
+      cost: optional<Money>
+      comment: optional<string>
+  InsurancePlan_SpecificCost:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: CodeableConcept
+      benefit: optional<list<InsurancePlan_Benefit1>>
+  InsurancePlan_Benefit1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      cost: optional<list<InsurancePlan_Cost>>
+  InsurancePlan_Cost:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      applicability: optional<CodeableConcept>
+      qualifiers: optional<list<CodeableConcept>>
+      value: optional<Quantity>
+  InvoiceStatus:
+    enum:
+      - draft
+      - issued
+      - balanced
+      - cancelled
+      # - entered-in-error
+  Invoice:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<InvoiceStatus>
+      cancelledReason: optional<string>
+      type: optional<CodeableConcept>
+      subject: optional<Reference>
+      recipient: optional<Reference>
+      date: optional<dateTime>
+      participant: optional<list<Invoice_Participant>>
+      issuer: optional<Reference>
+      account: optional<Reference>
+      lineItem: optional<list<Invoice_LineItem>>
+      totalPriceComponent: optional<list<Invoice_PriceComponent>>
+      totalNet: optional<Money>
+      totalGross: optional<Money>
+      paymentTerms: optional<markdown>
+      note: optional<list<Annotation>>
+  Invoice_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      role: optional<CodeableConcept>
+      actor: Reference
+  Invoice_LineItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequence: optional<positiveInt>
+      chargeItemReference: optional<Reference>
+      chargeItemCodeableConcept: optional<CodeableConcept>
+      priceComponent: optional<list<Invoice_PriceComponent>>
+  Invoice_pricecomponentType:
+    enum:
+      - base
+      - surcharge
+      - deduction
+      - discount
+      - tax
+      - informational
+  Invoice_PriceComponent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Invoice_pricecomponentType>
+      code: optional<CodeableConcept>
+      factor: optional<decimal>
+      amount: optional<Money>
+  LibraryStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  Library:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      status: optional<LibraryStatus>
+      experimental: optional<boolean>
+      type: CodeableConcept
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      parameter: optional<list<ParameterDefinition>>
+      dataRequirement: optional<list<DataRequirement>>
+      content: optional<list<Attachment>>
+  Linkage:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      active: optional<boolean>
+      author: optional<Reference>
+      item: list<Linkage_Item>
+  Linkage_itemType:
+    enum:
+      - source
+      - alternate
+      - historical
+  Linkage_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Linkage_itemType>
+      resource: Reference
+  ListStatus:
+    enum:
+      - current
+      - retired
+      - entered-in-error
+  ListMode:
+    enum:
+      - working
+      - snapshot
+      - changes
+  List:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<ListStatus>
+      mode: optional<ListMode>
+      title: optional<string>
+      code: optional<CodeableConcept>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      date: optional<dateTime>
+      source: optional<Reference>
+      orderedBy: optional<CodeableConcept>
+      note: optional<list<Annotation>>
+      entry: optional<list<List_Entry>>
+      emptyReason: optional<CodeableConcept>
+  List_Entry:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      flag: optional<CodeableConcept>
+      deleted: optional<boolean>
+      date: optional<dateTime>
+      item: Reference
+  LocationStatus:
+    enum:
+      - active
+      - suspended
+      - inactive
+  LocationMode:
+    enum:
+      - instance
+      - kind
+  Location:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<LocationStatus>
+      operationalStatus: optional<Coding>
+      name: optional<string>
+      alias: optional<list<string>>
+      description: optional<string>
+      mode: optional<LocationMode>
+      type: optional<list<CodeableConcept>>
+      telecom: optional<list<ContactPoint>>
+      address: optional<Address>
+      physicalType: optional<CodeableConcept>
+      position: optional<Location_Position>
+      managingOrganization: optional<Reference>
+      partOf: optional<Reference>
+      hoursOfOperation: optional<list<Location_HoursOfOperation>>
+      availabilityExceptions: optional<string>
+      endpoint: optional<list<Reference>>
+  Location_Position:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      longitude: optional<decimal>
+      latitude: optional<decimal>
+      altitude: optional<decimal>
+  Location_HoursOfOperation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      daysOfWeek: optional<list<code>>
+      allDay: optional<boolean>
+      openingTime: optional<time>
+      closingTime: optional<time>
+  MeasureStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  Measure:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      status: optional<MeasureStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      library: optional<list<canonical>>
+      disclaimer: optional<markdown>
+      scoring: optional<CodeableConcept>
+      compositeScoring: optional<CodeableConcept>
+      type: optional<list<CodeableConcept>>
+      riskAdjustment: optional<string>
+      rateAggregation: optional<string>
+      rationale: optional<markdown>
+      clinicalRecommendationStatement: optional<markdown>
+      improvementNotation: optional<CodeableConcept>
+      definition: optional<list<markdown>>
+      guidance: optional<markdown>
+      group: optional<list<Measure_Group>>
+      supplementalData: optional<list<Measure_SupplementalData>>
+  Measure_Group:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      population: optional<list<Measure_Population>>
+      stratifier: optional<list<Measure_Stratifier>>
+  Measure_Population:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      criteria: Expression
+  Measure_Stratifier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      criteria: optional<Expression>
+      component: optional<list<Measure_Component>>
+  Measure_Component:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      criteria: Expression
+  Measure_SupplementalData:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      usage: optional<list<CodeableConcept>>
+      description: optional<string>
+      criteria: Expression
+  MeasurereportStatus:
+    enum:
+      - complete
+      - pending
+      - error
+  MeasurereportType:
+    enum:
+      - individual
+      # - subject-list
+      - summary
+      - data-collection
+  MeasureReport:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<MeasurereportStatus>
+      type: optional<MeasurereportType>
+      measure: canonical
+      subject: optional<Reference>
+      date: optional<dateTime>
+      reporter: optional<Reference>
+      period: Period
+      improvementNotation: optional<CodeableConcept>
+      group: optional<list<MeasureReport_Group>>
+      evaluatedResource: optional<list<Reference>>
+  MeasureReport_Group:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      population: optional<list<MeasureReport_Population>>
+      measureScore: optional<Quantity>
+      stratifier: optional<list<MeasureReport_Stratifier>>
+  MeasureReport_Population:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      count: optional<integer>
+      subjectResults: optional<Reference>
+  MeasureReport_Stratifier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<list<CodeableConcept>>
+      stratum: optional<list<MeasureReport_Stratum>>
+  MeasureReport_Stratum:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      value: optional<CodeableConcept>
+      component: optional<list<MeasureReport_Component>>
+      population: optional<list<MeasureReport_Population1>>
+      measureScore: optional<Quantity>
+  MeasureReport_Component:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      value: CodeableConcept
+  MeasureReport_Population1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      count: optional<integer>
+      subjectResults: optional<Reference>
+  Media:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      type: optional<CodeableConcept>
+      modality: optional<CodeableConcept>
+      view: optional<CodeableConcept>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      createdDateTime: optional<string>
+      createdPeriod: optional<Period>
+      issued: optional<instant>
+      operator: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      bodySite: optional<CodeableConcept>
+      deviceName: optional<string>
+      device: optional<Reference>
+      height: optional<positiveInt>
+      width: optional<positiveInt>
+      frames: optional<positiveInt>
+      duration: optional<decimal>
+      content: Attachment
+      note: optional<list<Annotation>>
+  Medication:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      code: optional<CodeableConcept>
+      status: optional<code>
+      manufacturer: optional<Reference>
+      form: optional<CodeableConcept>
+      amount: optional<Ratio>
+      ingredient: optional<list<Medication_Ingredient>>
+      batch: optional<Medication_Batch>
+  Medication_Ingredient:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemCodeableConcept: optional<CodeableConcept>
+      itemReference: optional<Reference>
+      isActive: optional<boolean>
+      strength: optional<Ratio>
+  Medication_Batch:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      lotNumber: optional<string>
+      expirationDate: optional<dateTime>
+  MedicationAdministration:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiates: optional<list<uri>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      statusReason: optional<list<CodeableConcept>>
+      category: optional<CodeableConcept>
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+      subject: Reference
+      context: optional<Reference>
+      supportingInformation: optional<list<Reference>>
+      effectiveDateTime: optional<string>
+      effectivePeriod: optional<Period>
+      performer: optional<list<MedicationAdministration_Performer>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      request: optional<Reference>
+      device: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      dosage: optional<MedicationAdministration_Dosage>
+      eventHistory: optional<list<Reference>>
+  MedicationAdministration_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+  MedicationAdministration_Dosage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      text: optional<string>
+      site: optional<CodeableConcept>
+      route: optional<CodeableConcept>
+      method: optional<CodeableConcept>
+      dose: optional<Quantity>
+      rateRatio: optional<Ratio>
+      rateQuantity: optional<Quantity>
+  MedicationDispense:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      statusReasonCodeableConcept: optional<CodeableConcept>
+      statusReasonReference: optional<Reference>
+      category: optional<CodeableConcept>
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+      subject: optional<Reference>
+      context: optional<Reference>
+      supportingInformation: optional<list<Reference>>
+      performer: optional<list<MedicationDispense_Performer>>
+      location: optional<Reference>
+      authorizingPrescription: optional<list<Reference>>
+      type: optional<CodeableConcept>
+      quantity: optional<Quantity>
+      daysSupply: optional<Quantity>
+      whenPrepared: optional<dateTime>
+      whenHandedOver: optional<dateTime>
+      destination: optional<Reference>
+      receiver: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      dosageInstruction: optional<list<Dosage>>
+      substitution: optional<MedicationDispense_Substitution>
+      detectedIssue: optional<list<Reference>>
+      eventHistory: optional<list<Reference>>
+  MedicationDispense_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+  MedicationDispense_Substitution:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      wasSubstituted: optional<boolean>
+      type: optional<CodeableConcept>
+      reason: optional<list<CodeableConcept>>
+      responsibleParty: optional<list<Reference>>
+  MedicationKnowledge:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      status: optional<code>
+      manufacturer: optional<Reference>
+      doseForm: optional<CodeableConcept>
+      amount: optional<Quantity>
+      synonym: optional<list<string>>
+      relatedMedicationKnowledge: optional<list<MedicationKnowledge_RelatedMedicationKnowledge>>
+      associatedMedication: optional<list<Reference>>
+      productType: optional<list<CodeableConcept>>
+      monograph: optional<list<MedicationKnowledge_Monograph>>
+      ingredient: optional<list<MedicationKnowledge_Ingredient>>
+      preparationInstruction: optional<markdown>
+      intendedRoute: optional<list<CodeableConcept>>
+      cost: optional<list<MedicationKnowledge_Cost>>
+      monitoringProgram: optional<list<MedicationKnowledge_MonitoringProgram>>
+      administrationGuidelines: optional<list<MedicationKnowledge_AdministrationGuidelines>>
+      medicineClassification: optional<list<MedicationKnowledge_MedicineClassification>>
+      packaging: optional<MedicationKnowledge_Packaging>
+      drugCharacteristic: optional<list<MedicationKnowledge_DrugCharacteristic>>
+      contraindication: optional<list<Reference>>
+      regulatory: optional<list<MedicationKnowledge_Regulatory>>
+      kinetics: optional<list<MedicationKnowledge_Kinetics>>
+  MedicationKnowledge_RelatedMedicationKnowledge:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      reference: list<Reference>
+  MedicationKnowledge_Monograph:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      source: optional<Reference>
+  MedicationKnowledge_Ingredient:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemCodeableConcept: optional<CodeableConcept>
+      itemReference: optional<Reference>
+      isActive: optional<boolean>
+      strength: optional<Ratio>
+  MedicationKnowledge_Cost:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      source: optional<string>
+      cost: Money
+  MedicationKnowledge_MonitoringProgram:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      name: optional<string>
+  MedicationKnowledge_AdministrationGuidelines:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      dosage: optional<list<MedicationKnowledge_Dosage>>
+      indicationCodeableConcept: optional<CodeableConcept>
+      indicationReference: optional<Reference>
+      patientCharacteristics: optional<list<MedicationKnowledge_PatientCharacteristics>>
+  MedicationKnowledge_Dosage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      dosage: list<Dosage>
+  MedicationKnowledge_PatientCharacteristics:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      characteristicCodeableConcept: optional<CodeableConcept>
+      characteristicQuantity: optional<Quantity>
+      value: optional<list<string>>
+  MedicationKnowledge_MedicineClassification:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      classification: optional<list<CodeableConcept>>
+  MedicationKnowledge_Packaging:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      quantity: optional<Quantity>
+  MedicationKnowledge_DrugCharacteristic:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueString: optional<string>
+      valueQuantity: optional<Quantity>
+      valueBase64Binary: optional<string>
+  MedicationKnowledge_Regulatory:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      regulatoryAuthority: Reference
+      substitution: optional<list<MedicationKnowledge_Substitution>>
+      schedule: optional<list<MedicationKnowledge_Schedule>>
+      maxDispense: optional<MedicationKnowledge_MaxDispense>
+  MedicationKnowledge_Substitution:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      allowed: optional<boolean>
+  MedicationKnowledge_Schedule:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      schedule: CodeableConcept
+  MedicationKnowledge_MaxDispense:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      quantity: Quantity
+      period: optional<Duration>
+  MedicationKnowledge_Kinetics:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      areaUnderCurve: optional<list<Quantity>>
+      lethalDose50: optional<list<Quantity>>
+      halfLifePeriod: optional<Duration>
+  MedicationRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      intent: optional<code>
+      category: optional<list<CodeableConcept>>
+      priority: optional<code>
+      doNotPerform: optional<boolean>
+      reportedBoolean: optional<boolean>
+      reportedReference: optional<Reference>
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+      subject: Reference
+      encounter: optional<Reference>
+      supportingInformation: optional<list<Reference>>
+      authoredOn: optional<dateTime>
+      requester: optional<Reference>
+      performer: optional<Reference>
+      performerType: optional<CodeableConcept>
+      recorder: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      groupIdentifier: optional<Identifier>
+      courseOfTherapyType: optional<CodeableConcept>
+      insurance: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      dosageInstruction: optional<list<Dosage>>
+      dispenseRequest: optional<MedicationRequest_DispenseRequest>
+      substitution: optional<MedicationRequest_Substitution>
+      priorPrescription: optional<Reference>
+      detectedIssue: optional<list<Reference>>
+      eventHistory: optional<list<Reference>>
+  MedicationRequest_DispenseRequest:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      initialFill: optional<MedicationRequest_InitialFill>
+      dispenseInterval: optional<Duration>
+      validityPeriod: optional<Period>
+      numberOfRepeatsAllowed: optional<unsignedInt>
+      quantity: optional<Quantity>
+      expectedSupplyDuration: optional<Duration>
+      performer: optional<Reference>
+  MedicationRequest_InitialFill:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      quantity: optional<Quantity>
+      duration: optional<Duration>
+  MedicationRequest_Substitution:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      allowedBoolean: optional<boolean>
+      allowedCodeableConcept: optional<CodeableConcept>
+      reason: optional<CodeableConcept>
+  MedicationStatement:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      statusReason: optional<list<CodeableConcept>>
+      category: optional<CodeableConcept>
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+      subject: Reference
+      context: optional<Reference>
+      effectiveDateTime: optional<string>
+      effectivePeriod: optional<Period>
+      dateAsserted: optional<dateTime>
+      informationSource: optional<Reference>
+      derivedFrom: optional<list<Reference>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      dosage: optional<list<Dosage>>
+  MedicinalProduct:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: optional<CodeableConcept>
+      domain: optional<Coding>
+      combinedPharmaceuticalDoseForm: optional<CodeableConcept>
+      legalStatusOfSupply: optional<CodeableConcept>
+      additionalMonitoringIndicator: optional<CodeableConcept>
+      specialMeasures: optional<list<string>>
+      paediatricUseIndicator: optional<CodeableConcept>
+      productClassification: optional<list<CodeableConcept>>
+      marketingStatus: optional<list<MarketingStatus>>
+      pharmaceuticalProduct: optional<list<Reference>>
+      packagedMedicinalProduct: optional<list<Reference>>
+      attachedDocument: optional<list<Reference>>
+      masterFile: optional<list<Reference>>
+      contact: optional<list<Reference>>
+      clinicalTrial: optional<list<Reference>>
+      name: list<MedicinalProduct_Name>
+      crossReference: optional<list<Identifier>>
+      manufacturingBusinessOperation: optional<list<MedicinalProduct_ManufacturingBusinessOperation>>
+      specialDesignation: optional<list<MedicinalProduct_SpecialDesignation>>
+  MedicinalProduct_Name:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      productName: optional<string>
+      namePart: optional<list<MedicinalProduct_NamePart>>
+      countryLanguage: optional<list<MedicinalProduct_CountryLanguage>>
+  MedicinalProduct_NamePart:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      part: optional<string>
+      type: Coding
+  MedicinalProduct_CountryLanguage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      country: CodeableConcept
+      jurisdiction: optional<CodeableConcept>
+      language: CodeableConcept
+  MedicinalProduct_ManufacturingBusinessOperation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operationType: optional<CodeableConcept>
+      authorisationReferenceNumber: optional<Identifier>
+      effectiveDate: optional<dateTime>
+      confidentialityIndicator: optional<CodeableConcept>
+      manufacturer: optional<list<Reference>>
+      regulator: optional<Reference>
+  MedicinalProduct_SpecialDesignation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: optional<CodeableConcept>
+      intendedUse: optional<CodeableConcept>
+      indicationCodeableConcept: optional<CodeableConcept>
+      indicationReference: optional<Reference>
+      status: optional<CodeableConcept>
+      date: optional<dateTime>
+      species: optional<CodeableConcept>
+  MedicinalProductAuthorization:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      subject: optional<Reference>
+      country: optional<list<CodeableConcept>>
+      jurisdiction: optional<list<CodeableConcept>>
+      status: optional<CodeableConcept>
+      statusDate: optional<dateTime>
+      restoreDate: optional<dateTime>
+      validityPeriod: optional<Period>
+      dataExclusivityPeriod: optional<Period>
+      dateOfFirstAuthorization: optional<dateTime>
+      internationalBirthDate: optional<dateTime>
+      legalBasis: optional<CodeableConcept>
+      jurisdictionalAuthorization: >-
+        optional<list<MedicinalProductAuthorization_JurisdictionalAuthorization>>
+      holder: optional<Reference>
+      regulator: optional<Reference>
+      procedure: optional<MedicinalProductAuthorization_Procedure>
+  MedicinalProductAuthorization_JurisdictionalAuthorization:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      country: optional<CodeableConcept>
+      jurisdiction: optional<list<CodeableConcept>>
+      legalStatusOfSupply: optional<CodeableConcept>
+      validityPeriod: optional<Period>
+  MedicinalProductAuthorization_Procedure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      type: CodeableConcept
+      datePeriod: optional<Period>
+      dateDateTime: optional<string>
+      application: optional<list<MedicinalProductAuthorization_Procedure>>
+  MedicinalProductContraindication:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subject: optional<list<Reference>>
+      disease: optional<CodeableConcept>
+      diseaseStatus: optional<CodeableConcept>
+      comorbidity: optional<list<CodeableConcept>>
+      therapeuticIndication: optional<list<Reference>>
+      otherTherapy: optional<list<MedicinalProductContraindication_OtherTherapy>>
+      population: optional<list<Population>>
+  MedicinalProductContraindication_OtherTherapy:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      therapyRelationshipType: CodeableConcept
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+  MedicinalProductIndication:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subject: optional<list<Reference>>
+      diseaseSymptomProcedure: optional<CodeableConcept>
+      diseaseStatus: optional<CodeableConcept>
+      comorbidity: optional<list<CodeableConcept>>
+      intendedEffect: optional<CodeableConcept>
+      duration: optional<Quantity>
+      otherTherapy: optional<list<MedicinalProductIndication_OtherTherapy>>
+      undesirableEffect: optional<list<Reference>>
+      population: optional<list<Population>>
+  MedicinalProductIndication_OtherTherapy:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      therapyRelationshipType: CodeableConcept
+      medicationCodeableConcept: optional<CodeableConcept>
+      medicationReference: optional<Reference>
+  MedicinalProductIngredient:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      role: CodeableConcept
+      allergenicIndicator: optional<boolean>
+      manufacturer: optional<list<Reference>>
+      specifiedSubstance: optional<list<MedicinalProductIngredient_SpecifiedSubstance>>
+      substance: optional<MedicinalProductIngredient_Substance>
+  MedicinalProductIngredient_SpecifiedSubstance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      group: CodeableConcept
+      confidentiality: optional<CodeableConcept>
+      strength: optional<list<MedicinalProductIngredient_Strength>>
+  MedicinalProductIngredient_Strength:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      presentation: Ratio
+      presentationLowLimit: optional<Ratio>
+      concentration: optional<Ratio>
+      concentrationLowLimit: optional<Ratio>
+      measurementPoint: optional<string>
+      country: optional<list<CodeableConcept>>
+      referenceStrength: optional<list<MedicinalProductIngredient_ReferenceStrength>>
+  MedicinalProductIngredient_ReferenceStrength:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      substance: optional<CodeableConcept>
+      strength: Ratio
+      strengthLowLimit: optional<Ratio>
+      measurementPoint: optional<string>
+      country: optional<list<CodeableConcept>>
+  MedicinalProductIngredient_Substance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      strength: optional<list<MedicinalProductIngredient_Strength>>
+  MedicinalProductInteraction:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subject: optional<list<Reference>>
+      description: optional<string>
+      interactant: optional<list<MedicinalProductInteraction_Interactant>>
+      type: optional<CodeableConcept>
+      effect: optional<CodeableConcept>
+      incidence: optional<CodeableConcept>
+      management: optional<CodeableConcept>
+  MedicinalProductInteraction_Interactant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      itemReference: optional<Reference>
+      itemCodeableConcept: optional<CodeableConcept>
+  MedicinalProductManufactured:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      manufacturedDoseForm: CodeableConcept
+      unitOfPresentation: optional<CodeableConcept>
+      quantity: Quantity
+      manufacturer: optional<list<Reference>>
+      ingredient: optional<list<Reference>>
+      physicalCharacteristics: optional<ProdCharacteristic>
+      otherCharacteristics: optional<list<CodeableConcept>>
+  MedicinalProductPackaged:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      subject: optional<list<Reference>>
+      description: optional<string>
+      legalStatusOfSupply: optional<CodeableConcept>
+      marketingStatus: optional<list<MarketingStatus>>
+      marketingAuthorization: optional<Reference>
+      manufacturer: optional<list<Reference>>
+      batchIdentifier: optional<list<MedicinalProductPackaged_BatchIdentifier>>
+      packageItem: list<MedicinalProductPackaged_PackageItem>
+  MedicinalProductPackaged_BatchIdentifier:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      outerPackaging: Identifier
+      immediatePackaging: optional<Identifier>
+  MedicinalProductPackaged_PackageItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: CodeableConcept
+      quantity: Quantity
+      material: optional<list<CodeableConcept>>
+      alternateMaterial: optional<list<CodeableConcept>>
+      device: optional<list<Reference>>
+      manufacturedItem: optional<list<Reference>>
+      packageItem: optional<list<MedicinalProductPackaged_PackageItem>>
+      physicalCharacteristics: optional<ProdCharacteristic>
+      otherCharacteristics: optional<list<CodeableConcept>>
+      shelfLifeStorage: optional<list<ProductShelfLife>>
+      manufacturer: optional<list<Reference>>
+  MedicinalProductPharmaceutical:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      administrableDoseForm: CodeableConcept
+      unitOfPresentation: optional<CodeableConcept>
+      ingredient: optional<list<Reference>>
+      device: optional<list<Reference>>
+      characteristics: optional<list<MedicinalProductPharmaceutical_Characteristics>>
+      routeOfAdministration: list<MedicinalProductPharmaceutical_RouteOfAdministration>
+  MedicinalProductPharmaceutical_Characteristics:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      status: optional<CodeableConcept>
+  MedicinalProductPharmaceutical_RouteOfAdministration:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      firstDose: optional<Quantity>
+      maxSingleDose: optional<Quantity>
+      maxDosePerDay: optional<Quantity>
+      maxDosePerTreatmentPeriod: optional<Ratio>
+      maxTreatmentPeriod: optional<Duration>
+      targetSpecies: optional<list<MedicinalProductPharmaceutical_TargetSpecies>>
+  MedicinalProductPharmaceutical_TargetSpecies:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      withdrawalPeriod: optional<list<MedicinalProductPharmaceutical_WithdrawalPeriod>>
+  MedicinalProductPharmaceutical_WithdrawalPeriod:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      tissue: CodeableConcept
+      value: Quantity
+      supportingInformation: optional<string>
+  MedicinalProductUndesirableEffect:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subject: optional<list<Reference>>
+      symptomConditionEffect: optional<CodeableConcept>
+      classification: optional<CodeableConcept>
+      frequencyOfOccurrence: optional<CodeableConcept>
+      population: optional<list<Population>>
+  MessagedefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  MessagedefinitionCategory:
+    enum:
+      - consequence
+      - currency
+      - notification
+  MessagedefinitionResponserequired:
+    enum:
+      - always
+      # - on-error
+      - never
+      # - on-success
+  MessageDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      replaces: optional<list<canonical>>
+      status: optional<MessagedefinitionStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      base: optional<canonical>
+      parent: optional<list<canonical>>
+      eventCoding: optional<Coding>
+      eventUri: optional<string>
+      category: optional<MessagedefinitionCategory>
+      focus: optional<list<MessageDefinition_Focus>>
+      responseRequired: optional<MessagedefinitionResponserequired>
+      allowedResponse: optional<list<MessageDefinition_AllowedResponse>>
+      graph: optional<list<canonical>>
+  MessageDefinition_Focus:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      profile: optional<canonical>
+      min: optional<unsignedInt>
+      max: optional<string>
+  MessageDefinition_AllowedResponse:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      message: canonical
+      situation: optional<markdown>
+  MessageHeader:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      eventCoding: optional<Coding>
+      eventUri: optional<string>
+      destination: optional<list<MessageHeader_Destination>>
+      sender: optional<Reference>
+      enterer: optional<Reference>
+      author: optional<Reference>
+      source: MessageHeader_Source
+      responsible: optional<Reference>
+      reason: optional<CodeableConcept>
+      response: optional<MessageHeader_Response>
+      focus: optional<list<Reference>>
+      definition: optional<canonical>
+  MessageHeader_Destination:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      target: optional<Reference>
+      endpoint: optional<url>
+      receiver: optional<Reference>
+  MessageHeader_Source:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      software: optional<string>
+      version: optional<string>
+      contact: optional<ContactPoint>
+      endpoint: optional<url>
+  Messageheader_responseCode:
+    enum:
+      - ok
+      # - transient-error
+      # - fatal-error
+  MessageHeader_Response:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<id>
+      code: optional<Messageheader_responseCode>
+      details: optional<Reference>
+  MolecularsequenceType:
+    enum:
+      - aa
+      - dna
+      - rna
+  MolecularSequence:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      type: optional<MolecularsequenceType>
+      coordinateSystem: optional<integer>
+      patient: optional<Reference>
+      specimen: optional<Reference>
+      device: optional<Reference>
+      performer: optional<Reference>
+      quantity: optional<Quantity>
+      referenceSeq: optional<MolecularSequence_ReferenceSeq>
+      variant: optional<list<MolecularSequence_Variant>>
+      observedSeq: optional<string>
+      quality: optional<list<MolecularSequence_Quality>>
+      readCoverage: optional<integer>
+      repository: optional<list<MolecularSequence_Repository>>
+      pointer: optional<list<Reference>>
+      structureVariant: optional<list<MolecularSequence_StructureVariant>>
+  Molecularsequence_referenceseqOrientation:
+    enum:
+      - sense
+      - antisense
+  Molecularsequence_referenceseqStrand:
+    enum:
+      - watson
+      - crick
+  MolecularSequence_ReferenceSeq:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      chromosome: optional<CodeableConcept>
+      genomeBuild: optional<string>
+      orientation: optional<Molecularsequence_referenceseqOrientation>
+      referenceSeqId: optional<CodeableConcept>
+      referenceSeqPointer: optional<Reference>
+      referenceSeqString: optional<string>
+      strand: optional<Molecularsequence_referenceseqStrand>
+      windowStart: optional<integer>
+      windowEnd: optional<integer>
+  MolecularSequence_Variant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      start: optional<integer>
+      end: optional<integer>
+      observedAllele: optional<string>
+      referenceAllele: optional<string>
+      cigar: optional<string>
+      variantPointer: optional<Reference>
+  Molecularsequence_qualityType:
+    enum:
+      - indel
+      - snp
+      - unknown
+  MolecularSequence_Quality:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Molecularsequence_qualityType>
+      standardSequence: optional<CodeableConcept>
+      start: optional<integer>
+      end: optional<integer>
+      score: optional<Quantity>
+      method: optional<CodeableConcept>
+      truthTP: optional<decimal>
+      queryTP: optional<decimal>
+      truthFN: optional<decimal>
+      queryFP: optional<decimal>
+      gtFP: optional<decimal>
+      precision: optional<decimal>
+      recall: optional<decimal>
+      fScore: optional<decimal>
+      roc: optional<MolecularSequence_Roc>
+  MolecularSequence_Roc:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      score: optional<list<integer>>
+      numTP: optional<list<integer>>
+      numFP: optional<list<integer>>
+      numFN: optional<list<integer>>
+      precision: optional<list<decimal>>
+      sensitivity: optional<list<decimal>>
+      fMeasure: optional<list<decimal>>
+  Molecularsequence_repositoryType:
+    enum:
+      - directlink
+      - openapi
+      - login
+      - oauth
+      - other
+  MolecularSequence_Repository:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Molecularsequence_repositoryType>
+      url: optional<uri>
+      name: optional<string>
+      datasetId: optional<string>
+      variantsetId: optional<string>
+      readsetId: optional<string>
+  MolecularSequence_StructureVariant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      variantType: optional<CodeableConcept>
+      exact: optional<boolean>
+      length: optional<integer>
+      outer: optional<MolecularSequence_Outer>
+      inner: optional<MolecularSequence_Inner>
+  MolecularSequence_Outer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      start: optional<integer>
+      end: optional<integer>
+  MolecularSequence_Inner:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      start: optional<integer>
+      end: optional<integer>
+  NamingsystemStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  NamingsystemKind:
+    enum:
+      - codesystem
+      - identifier
+      - root
+  NamingSystem:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      status: optional<NamingsystemStatus>
+      kind: optional<NamingsystemKind>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      responsible: optional<string>
+      type: optional<CodeableConcept>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      usage: optional<string>
+      uniqueId: list<NamingSystem_UniqueId>
+  Namingsystem_uniqueidType:
+    enum:
+      - oid
+      - uuid
+      - uri
+      - other
+  NamingSystem_UniqueId:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Namingsystem_uniqueidType>
+      value: optional<string>
+      preferred: optional<boolean>
+      comment: optional<string>
+      period: optional<Period>
+  NutritionOrder:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      instantiates: optional<list<uri>>
+      status: optional<code>
+      intent: optional<code>
+      patient: Reference
+      encounter: optional<Reference>
+      dateTime: optional<dateTime>
+      orderer: optional<Reference>
+      allergyIntolerance: optional<list<Reference>>
+      foodPreferenceModifier: optional<list<CodeableConcept>>
+      excludeFoodModifier: optional<list<CodeableConcept>>
+      oralDiet: optional<NutritionOrder_OralDiet>
+      supplement: optional<list<NutritionOrder_Supplement>>
+      enteralFormula: optional<NutritionOrder_EnteralFormula>
+      note: optional<list<Annotation>>
+  NutritionOrder_OralDiet:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<list<CodeableConcept>>
+      schedule: optional<list<Timing>>
+      nutrient: optional<list<NutritionOrder_Nutrient>>
+      texture: optional<list<NutritionOrder_Texture>>
+      fluidConsistencyType: optional<list<CodeableConcept>>
+      instruction: optional<string>
+  NutritionOrder_Nutrient:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      modifier: optional<CodeableConcept>
+      amount: optional<Quantity>
+  NutritionOrder_Texture:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      modifier: optional<CodeableConcept>
+      foodType: optional<CodeableConcept>
+  NutritionOrder_Supplement:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      productName: optional<string>
+      schedule: optional<list<Timing>>
+      quantity: optional<Quantity>
+      instruction: optional<string>
+  NutritionOrder_EnteralFormula:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      baseFormulaType: optional<CodeableConcept>
+      baseFormulaProductName: optional<string>
+      additiveType: optional<CodeableConcept>
+      additiveProductName: optional<string>
+      caloricDensity: optional<Quantity>
+      routeofAdministration: optional<CodeableConcept>
+      administration: optional<list<NutritionOrder_Administration>>
+      maxVolumeToDeliver: optional<Quantity>
+      administrationInstruction: optional<string>
+  NutritionOrder_Administration:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      schedule: optional<Timing>
+      quantity: optional<Quantity>
+      rateQuantity: optional<Quantity>
+      rateRatio: optional<Ratio>
+  ObservationStatus:
+    enum:
+      - registered
+      - preliminary
+      - final
+      - amended
+      - corrected
+      - cancelled
+      - entered-in-error
+      - unknown
+  Observation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<ObservationStatus>
+      category: optional<list<CodeableConcept>>
+      code: CodeableConcept
+      subject: optional<Reference>
+      focus: optional<list<Reference>>
+      encounter: optional<Reference>
+      effectiveDateTime: optional<string>
+      effectivePeriod: optional<Period>
+      effectiveTiming: optional<Timing>
+      effectiveInstant: optional<string>
+      issued: optional<instant>
+      performer: optional<list<Reference>>
+      valueQuantity: optional<Quantity>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueString: optional<string>
+      valueBoolean: optional<boolean>
+      valueInteger: optional<double>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueSampledData: optional<SampledData>
+      valueTime: optional<string>
+      valueDateTime: optional<string>
+      valuePeriod: optional<Period>
+      dataAbsentReason: optional<CodeableConcept>
+      interpretation: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+      bodySite: optional<CodeableConcept>
+      method: optional<CodeableConcept>
+      specimen: optional<Reference>
+      device: optional<Reference>
+      referenceRange: optional<list<Observation_ReferenceRange>>
+      hasMember: optional<list<Reference>>
+      derivedFrom: optional<list<Reference>>
+      component: optional<list<Observation_Component>>
+  Observation_ReferenceRange:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      low: optional<Quantity>
+      high: optional<Quantity>
+      type: optional<CodeableConcept>
+      appliesTo: optional<list<CodeableConcept>>
+      age: optional<Range>
+      text: optional<string>
+  Observation_Component:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: CodeableConcept
+      valueQuantity: optional<Quantity>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueString: optional<string>
+      valueBoolean: optional<boolean>
+      valueInteger: optional<double>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueSampledData: optional<SampledData>
+      valueTime: optional<string>
+      valueDateTime: optional<string>
+      valuePeriod: optional<Period>
+      dataAbsentReason: optional<CodeableConcept>
+      interpretation: optional<list<CodeableConcept>>
+      referenceRange: optional<list<Observation_ReferenceRange>>
+  ObservationdefinitionPermitteddatatypeItem:
+    enum:
+      - Quantity
+      - CodeableConcept
+      - string
+      - boolean
+      - integer
+      - Range
+      - Ratio
+      - SampledData
+      - time
+      - dateTime
+      - Period
+  ObservationDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: optional<list<CodeableConcept>>
+      code: CodeableConcept
+      identifier: optional<list<Identifier>>
+      permittedDataType: optional<list<ObservationdefinitionPermitteddatatypeItem>>
+      multipleResultsAllowed: optional<boolean>
+      method: optional<CodeableConcept>
+      preferredReportName: optional<string>
+      quantitativeDetails: optional<ObservationDefinition_QuantitativeDetails>
+      qualifiedInterval: optional<list<ObservationDefinition_QualifiedInterval>>
+      validCodedValueSet: optional<Reference>
+      normalCodedValueSet: optional<Reference>
+      abnormalCodedValueSet: optional<Reference>
+      criticalCodedValueSet: optional<Reference>
+  ObservationDefinition_QuantitativeDetails:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      customaryUnit: optional<CodeableConcept>
+      unit: optional<CodeableConcept>
+      conversionFactor: optional<decimal>
+      decimalPrecision: optional<integer>
+  Observationdefinition_qualifiedintervalCategory:
+    enum:
+      - reference
+      - critical
+      - absolute
+  Observationdefinition_qualifiedintervalGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  ObservationDefinition_QualifiedInterval:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: optional<Observationdefinition_qualifiedintervalCategory>
+      range: optional<Range>
+      context: optional<CodeableConcept>
+      appliesTo: optional<list<CodeableConcept>>
+      gender: optional<Observationdefinition_qualifiedintervalGender>
+      age: optional<Range>
+      gestationalAge: optional<Range>
+      condition: optional<string>
+  OperationdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  OperationdefinitionKind:
+    enum:
+      - operation
+      - query
+  OperationDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<OperationdefinitionStatus>
+      kind: optional<OperationdefinitionKind>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      affectsState: optional<boolean>
+      code: optional<code>
+      comment: optional<markdown>
+      base: optional<canonical>
+      resource: optional<list<code>>
+      system: optional<boolean>
+      type: optional<boolean>
+      instance: optional<boolean>
+      inputProfile: optional<canonical>
+      outputProfile: optional<canonical>
+      parameter: optional<list<OperationDefinition_Parameter>>
+      overload: optional<list<OperationDefinition_Overload>>
+  Operationdefinition_parameterUse:
+    enum:
+      - in
+      - out
+  Operationdefinition_parameterSearchtype:
+    enum:
+      - number
+      - date
+      - string
+      - token
+      - reference
+      - composite
+      - quantity
+      - uri
+      - special
+  OperationDefinition_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<code>
+      use: optional<Operationdefinition_parameterUse>
+      min: optional<integer>
+      max: optional<string>
+      documentation: optional<string>
+      type: optional<code>
+      targetProfile: optional<list<canonical>>
+      searchType: optional<Operationdefinition_parameterSearchtype>
+      binding: optional<OperationDefinition_Binding>
+      referencedFrom: optional<list<OperationDefinition_ReferencedFrom>>
+      part: optional<list<OperationDefinition_Parameter>>
+  Operationdefinition_bindingStrength:
+    enum:
+      - required
+      - extensible
+      - preferred
+      - example
+  OperationDefinition_Binding:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      strength: optional<Operationdefinition_bindingStrength>
+      valueSet: canonical
+  OperationDefinition_ReferencedFrom:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      source: optional<string>
+      sourceId: optional<string>
+  OperationDefinition_Overload:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      parameterName: optional<list<string>>
+      comment: optional<string>
+  OperationOutcome:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      issue: list<OperationOutcome_Issue>
+      status: optional<integer>
+      resource: optional<ResourceList>
+  Operationoutcome_issueSeverity:
+    enum:
+      - fatal
+      - error
+      - warning
+      - information
+  Operationoutcome_issueCode:
+    enum:
+      - invalid
+      - structure
+      - required
+      - value
+      - invariant
+      - security
+      - login
+      - unknown
+      - expired
+      - forbidden
+      - suppressed
+      - processing
+      # - not-supported
+      - duplicate
+      # - multiple-matches
+      # - not-found
+      - deleted
+      # - too-long
+      # - code-invalid
+      - extension
+      # - too-costly
+      # - business-rule
+      - conflict
+      - transient
+      # - lock-error
+      # - no-store
+      - exception
+      - timeout
+      - incomplete
+      - throttled
+      - informational
+  OperationOutcome_Issue:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      severity: optional<Operationoutcome_issueSeverity>
+      code: optional<Operationoutcome_issueCode>
+      details: optional<CodeableConcept>
+      diagnostics: optional<string>
+      location: optional<list<string>>
+      expression: optional<list<string>>
+  Organization:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      type: optional<list<CodeableConcept>>
+      name: optional<string>
+      alias: optional<list<string>>
+      telecom: optional<list<ContactPoint>>
+      address: optional<list<Address>>
+      partOf: optional<Reference>
+      contact: optional<list<Organization_Contact>>
+      endpoint: optional<list<Reference>>
+  Organization_Contact:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      purpose: optional<CodeableConcept>
+      name: optional<HumanName>
+      telecom: optional<list<ContactPoint>>
+      address: optional<Address>
+  OrganizationAffiliation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      period: optional<Period>
+      organization: optional<Reference>
+      participatingOrganization: optional<Reference>
+      network: optional<list<Reference>>
+      code: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      location: optional<list<Reference>>
+      healthcareService: optional<list<Reference>>
+      telecom: optional<list<ContactPoint>>
+      endpoint: optional<list<Reference>>
+  Parameters:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      parameter: optional<list<Parameters_Parameter>>
+  Parameters_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      valueBase64Binary: optional<string>
+      valueBoolean: optional<boolean>
+      valueCanonical: optional<string>
+      valueCode: optional<string>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+      valueId: optional<string>
+      valueInstant: optional<string>
+      valueInteger: optional<double>
+      valueMarkdown: optional<string>
+      valueOid: optional<string>
+      valuePositiveInt: optional<double>
+      valueString: optional<string>
+      valueTime: optional<string>
+      valueUnsignedInt: optional<double>
+      valueUri: optional<string>
+      valueUrl: optional<string>
+      valueUuid: optional<string>
+      valueAddress: optional<Address>
+      valueAge: optional<Age>
+      valueAnnotation: optional<Annotation>
+      valueAttachment: optional<Attachment>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueCoding: optional<Coding>
+      valueContactPoint: optional<ContactPoint>
+      valueCount: optional<Count>
+      valueDistance: optional<Distance>
+      valueDuration: optional<Duration>
+      valueHumanName: optional<HumanName>
+      valueIdentifier: optional<Identifier>
+      valueMoney: optional<Money>
+      valuePeriod: optional<Period>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueReference: optional<Reference>
+      valueSampledData: optional<SampledData>
+      valueSignature: optional<Signature>
+      valueTiming: optional<Timing>
+      valueContactDetail: optional<ContactDetail>
+      valueContributor: optional<Contributor>
+      valueDataRequirement: optional<DataRequirement>
+      valueExpression: optional<Expression>
+      valueParameterDefinition: optional<ParameterDefinition>
+      valueRelatedArtifact: optional<RelatedArtifact>
+      valueTriggerDefinition: optional<TriggerDefinition>
+      valueUsageContext: optional<UsageContext>
+      valueDosage: optional<Dosage>
+      valueMeta: optional<Meta>
+      resource: optional<ResourceList>
+      part: optional<list<Parameters_Parameter>>
+  PatientGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  Patient:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      name: optional<list<HumanName>>
+      telecom: optional<list<ContactPoint>>
+      gender: optional<PatientGender>
+      birthDate: optional<date>
+      deceasedBoolean: optional<boolean>
+      deceasedDateTime: optional<string>
+      address: optional<list<Address>>
+      maritalStatus: optional<CodeableConcept>
+      multipleBirthBoolean: optional<boolean>
+      multipleBirthInteger: optional<double>
+      photo: optional<list<Attachment>>
+      contact: optional<list<Patient_Contact>>
+      communication: optional<list<Patient_Communication>>
+      generalPractitioner: optional<list<Reference>>
+      managingOrganization: optional<Reference>
+      link: optional<list<Patient_Link>>
+  Patient_contactGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  Patient_Contact:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      relationship: optional<list<CodeableConcept>>
+      name: optional<HumanName>
+      telecom: optional<list<ContactPoint>>
+      address: optional<Address>
+      gender: optional<Patient_contactGender>
+      organization: optional<Reference>
+      period: optional<Period>
+  Patient_Communication:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      language: CodeableConcept
+      preferred: optional<boolean>
+  Patient_linkType:
+    enum:
+      # - replaced-by
+      - replaces
+      - refer
+      - seealso
+  Patient_Link:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      other: Reference
+      type: optional<Patient_linkType>
+  PaymentNotice:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      request: optional<Reference>
+      response: optional<Reference>
+      created: optional<dateTime>
+      provider: optional<Reference>
+      payment: Reference
+      paymentDate: optional<date>
+      payee: optional<Reference>
+      recipient: Reference
+      amount: Money
+      paymentStatus: optional<CodeableConcept>
+  PaymentreconciliationOutcome:
+    enum:
+      - queued
+      - complete
+      - error
+      - partial
+  PaymentReconciliation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      period: optional<Period>
+      created: optional<dateTime>
+      paymentIssuer: optional<Reference>
+      request: optional<Reference>
+      requestor: optional<Reference>
+      outcome: optional<PaymentreconciliationOutcome>
+      disposition: optional<string>
+      paymentDate: optional<date>
+      paymentAmount: Money
+      paymentIdentifier: optional<Identifier>
+      detail: optional<list<PaymentReconciliation_Detail>>
+      formCode: optional<CodeableConcept>
+      processNote: optional<list<PaymentReconciliation_ProcessNote>>
+  PaymentReconciliation_Detail:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      predecessor: optional<Identifier>
+      type: CodeableConcept
+      request: optional<Reference>
+      submitter: optional<Reference>
+      response: optional<Reference>
+      date: optional<date>
+      responsible: optional<Reference>
+      payee: optional<Reference>
+      amount: optional<Money>
+  Paymentreconciliation_processnoteType:
+    enum:
+      - display
+      - print
+      - printoper
+  PaymentReconciliation_ProcessNote:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Paymentreconciliation_processnoteType>
+      text: optional<string>
+  PersonGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  Person:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      name: optional<list<HumanName>>
+      telecom: optional<list<ContactPoint>>
+      gender: optional<PersonGender>
+      birthDate: optional<date>
+      address: optional<list<Address>>
+      photo: optional<Attachment>
+      managingOrganization: optional<Reference>
+      active: optional<boolean>
+      link: optional<list<Person_Link>>
+  Person_linkAssurance:
+    enum:
+      - level1
+      - level2
+      - level3
+      - level4
+  Person_Link:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      target: Reference
+      assurance: optional<Person_linkAssurance>
+  PlandefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  PlanDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      subtitle: optional<string>
+      type: optional<CodeableConcept>
+      status: optional<PlandefinitionStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      library: optional<list<canonical>>
+      goal: optional<list<PlanDefinition_Goal>>
+      action: optional<list<PlanDefinition_Action>>
+  PlanDefinition_Goal:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: optional<CodeableConcept>
+      description: CodeableConcept
+      priority: optional<CodeableConcept>
+      start: optional<CodeableConcept>
+      addresses: optional<list<CodeableConcept>>
+      documentation: optional<list<RelatedArtifact>>
+      target: optional<list<PlanDefinition_Target>>
+  PlanDefinition_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      measure: optional<CodeableConcept>
+      detailQuantity: optional<Quantity>
+      detailRange: optional<Range>
+      detailCodeableConcept: optional<CodeableConcept>
+      due: optional<Duration>
+  Plandefinition_actionGroupingbehavior:
+    enum:
+      []
+      # - visual-group
+      # - logical-group
+      # - sentence-group
+  Plandefinition_actionSelectionbehavior:
+    enum:
+      - any
+      - all
+      # - all-or-none
+      # - exactly-one
+      # - at-most-one
+      # - one-or-more
+  Plandefinition_actionRequiredbehavior:
+    enum:
+      - must
+      - could
+      # - must-unless-documented
+  Plandefinition_actionPrecheckbehavior:
+    enum:
+      - "yes"
+      - "no"
+  Plandefinition_actionCardinalitybehavior:
+    enum:
+      - single
+      - multiple
+  PlanDefinition_Action:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      prefix: optional<string>
+      title: optional<string>
+      description: optional<string>
+      textEquivalent: optional<string>
+      priority: optional<code>
+      code: optional<list<CodeableConcept>>
+      reason: optional<list<CodeableConcept>>
+      documentation: optional<list<RelatedArtifact>>
+      goalId: optional<list<id>>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      trigger: optional<list<TriggerDefinition>>
+      condition: optional<list<PlanDefinition_Condition>>
+      input: optional<list<DataRequirement>>
+      output: optional<list<DataRequirement>>
+      relatedAction: optional<list<PlanDefinition_RelatedAction>>
+      timingDateTime: optional<string>
+      timingAge: optional<Age>
+      timingPeriod: optional<Period>
+      timingDuration: optional<Duration>
+      timingRange: optional<Range>
+      timingTiming: optional<Timing>
+      participant: optional<list<PlanDefinition_Participant>>
+      type: optional<CodeableConcept>
+      groupingBehavior: optional<Plandefinition_actionGroupingbehavior>
+      selectionBehavior: optional<Plandefinition_actionSelectionbehavior>
+      requiredBehavior: optional<Plandefinition_actionRequiredbehavior>
+      precheckBehavior: optional<Plandefinition_actionPrecheckbehavior>
+      cardinalityBehavior: optional<Plandefinition_actionCardinalitybehavior>
+      definitionCanonical: optional<string>
+      definitionUri: optional<string>
+      transform: optional<canonical>
+      dynamicValue: optional<list<PlanDefinition_DynamicValue>>
+      action: optional<list<PlanDefinition_Action>>
+  Plandefinition_conditionKind:
+    enum:
+      - applicability
+      - start
+      - stop
+  PlanDefinition_Condition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      kind: optional<Plandefinition_conditionKind>
+      expression: optional<Expression>
+  Plandefinition_relatedactionRelationship:
+    enum:
+      # - before-start
+      - before
+      # - before-end
+      # - concurrent-with-start
+      - concurrent
+      # - concurrent-with-end
+      # - after-start
+      - after
+      # - after-end
+  PlanDefinition_RelatedAction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      actionId: optional<id>
+      relationship: optional<Plandefinition_relatedactionRelationship>
+      offsetDuration: optional<Duration>
+      offsetRange: optional<Range>
+  Plandefinition_participantType:
+    enum:
+      - patient
+      - practitioner
+      # - related-person
+      - device
+  PlanDefinition_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Plandefinition_participantType>
+      role: optional<CodeableConcept>
+  PlanDefinition_DynamicValue:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      path: optional<string>
+      expression: optional<Expression>
+  PractitionerGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  Practitioner:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      name: optional<list<HumanName>>
+      telecom: optional<list<ContactPoint>>
+      address: optional<list<Address>>
+      gender: optional<PractitionerGender>
+      birthDate: optional<date>
+      photo: optional<list<Attachment>>
+      qualification: optional<list<Practitioner_Qualification>>
+      communication: optional<list<CodeableConcept>>
+  Practitioner_Qualification:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      code: CodeableConcept
+      period: optional<Period>
+      issuer: optional<Reference>
+  PractitionerRole:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      period: optional<Period>
+      practitioner: optional<Reference>
+      organization: optional<Reference>
+      code: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      location: optional<list<Reference>>
+      healthcareService: optional<list<Reference>>
+      telecom: optional<list<ContactPoint>>
+      availableTime: optional<list<PractitionerRole_AvailableTime>>
+      notAvailable: optional<list<PractitionerRole_NotAvailable>>
+      availabilityExceptions: optional<string>
+      endpoint: optional<list<Reference>>
+  PractitionerRole_AvailableTime:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      daysOfWeek: optional<list<code>>
+      allDay: optional<boolean>
+      availableStartTime: optional<time>
+      availableEndTime: optional<time>
+  PractitionerRole_NotAvailable:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      during: optional<Period>
+  Procedure:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<code>
+      statusReason: optional<CodeableConcept>
+      category: optional<CodeableConcept>
+      code: optional<CodeableConcept>
+      subject: Reference
+      encounter: optional<Reference>
+      performedDateTime: optional<string>
+      performedPeriod: optional<Period>
+      performedString: optional<string>
+      performedAge: optional<Age>
+      performedRange: optional<Range>
+      recorder: optional<Reference>
+      asserter: optional<Reference>
+      performer: optional<list<Procedure_Performer>>
+      location: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      bodySite: optional<list<CodeableConcept>>
+      outcome: optional<CodeableConcept>
+      report: optional<list<Reference>>
+      complication: optional<list<CodeableConcept>>
+      complicationDetail: optional<list<Reference>>
+      followUp: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+      focalDevice: optional<list<Procedure_FocalDevice>>
+      usedReference: optional<list<Reference>>
+      usedCode: optional<list<CodeableConcept>>
+  Procedure_Performer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      function: optional<CodeableConcept>
+      actor: Reference
+      onBehalfOf: optional<Reference>
+  Procedure_FocalDevice:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: optional<CodeableConcept>
+      manipulated: Reference
+  Provenance:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      target: list<Reference>
+      occurredPeriod: optional<Period>
+      occurredDateTime: optional<string>
+      recorded: optional<instant>
+      policy: optional<list<uri>>
+      location: optional<Reference>
+      reason: optional<list<CodeableConcept>>
+      activity: optional<CodeableConcept>
+      agent: list<Provenance_Agent>
+      entity: optional<list<Provenance_Entity>>
+      signature: optional<list<Signature>>
+  Provenance_Agent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      role: optional<list<CodeableConcept>>
+      who: Reference
+      onBehalfOf: optional<Reference>
+  Provenance_entityRole:
+    enum:
+      - derivation
+      - revision
+      - quotation
+      - source
+      - removal
+  Provenance_Entity:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      role: optional<Provenance_entityRole>
+      what: Reference
+      agent: optional<list<Provenance_Agent>>
+  QuestionnaireStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  Questionnaire:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      derivedFrom: optional<list<canonical>>
+      status: optional<QuestionnaireStatus>
+      experimental: optional<boolean>
+      subjectType: optional<list<code>>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      code: optional<list<Coding>>
+      item: optional<list<Questionnaire_Item>>
+  Questionnaire_itemType:
+    enum:
+      - group
+      - display
+      - boolean
+      - decimal
+      - integer
+      - date
+      - dateTime
+      - time
+      - string
+      - text
+      - url
+      - choice
+      # - open-choice
+      - attachment
+      - reference
+      - quantity
+  Questionnaire_itemEnablebehavior:
+    enum:
+      - all
+      - any
+  Questionnaire_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      linkId: optional<string>
+      definition: optional<uri>
+      code: optional<list<Coding>>
+      prefix: optional<string>
+      text: optional<string>
+      type: optional<Questionnaire_itemType>
+      enableWhen: optional<list<Questionnaire_EnableWhen>>
+      enableBehavior: optional<Questionnaire_itemEnablebehavior>
+      required: optional<boolean>
+      repeats: optional<boolean>
+      readOnly: optional<boolean>
+      maxLength: optional<integer>
+      answerValueSet: optional<canonical>
+      answerOption: optional<list<Questionnaire_AnswerOption>>
+      initial: optional<list<Questionnaire_Initial>>
+      item: optional<list<Questionnaire_Item>>
+  Questionnaire_enablewhenOperator:
+    enum:
+      - exists
+      # - "="
+      # - "!="
+      # - ">"
+      # - <
+      # - ">="
+      # - <=
+  Questionnaire_EnableWhen:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      question: optional<string>
+      operator: optional<Questionnaire_enablewhenOperator>
+      answerBoolean: optional<boolean>
+      answerDecimal: optional<double>
+      answerInteger: optional<double>
+      answerDate: optional<string>
+      answerDateTime: optional<string>
+      answerTime: optional<string>
+      answerString: optional<string>
+      answerCoding: optional<Coding>
+      answerQuantity: optional<Quantity>
+      answerReference: optional<Reference>
+  Questionnaire_AnswerOption:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      valueInteger: optional<double>
+      valueDate: optional<string>
+      valueTime: optional<string>
+      valueString: optional<string>
+      valueCoding: optional<Coding>
+      valueReference: optional<Reference>
+      initialSelected: optional<boolean>
+  Questionnaire_Initial:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      valueBoolean: optional<boolean>
+      valueDecimal: optional<double>
+      valueInteger: optional<double>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueTime: optional<string>
+      valueString: optional<string>
+      valueUri: optional<string>
+      valueAttachment: optional<Attachment>
+      valueCoding: optional<Coding>
+      valueQuantity: optional<Quantity>
+      valueReference: optional<Reference>
+  QuestionnaireresponseStatus:
+    enum:
+      # - in-progress
+      - completed
+      - amended
+      # - entered-in-error
+      - stopped
+  QuestionnaireResponse:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      questionnaire: optional<canonical>
+      status: optional<QuestionnaireresponseStatus>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      authored: optional<dateTime>
+      author: optional<Reference>
+      source: optional<Reference>
+      item: optional<list<QuestionnaireResponse_Item>>
+  QuestionnaireResponse_Item:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      linkId: optional<string>
+      definition: optional<uri>
+      text: optional<string>
+      answer: optional<list<QuestionnaireResponse_Answer>>
+      item: optional<list<QuestionnaireResponse_Item>>
+  QuestionnaireResponse_Answer:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      valueBoolean: optional<boolean>
+      valueDecimal: optional<double>
+      valueInteger: optional<double>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueTime: optional<string>
+      valueString: optional<string>
+      valueUri: optional<string>
+      valueAttachment: optional<Attachment>
+      valueCoding: optional<Coding>
+      valueQuantity: optional<Quantity>
+      valueReference: optional<Reference>
+      item: optional<list<QuestionnaireResponse_Item>>
+  RelatedpersonGender:
+    enum:
+      - male
+      - female
+      - other
+      - unknown
+  RelatedPerson:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      patient: Reference
+      relationship: optional<list<CodeableConcept>>
+      name: optional<list<HumanName>>
+      telecom: optional<list<ContactPoint>>
+      gender: optional<RelatedpersonGender>
+      birthDate: optional<date>
+      address: optional<list<Address>>
+      photo: optional<list<Attachment>>
+      period: optional<Period>
+      communication: optional<list<RelatedPerson_Communication>>
+  RelatedPerson_Communication:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      language: CodeableConcept
+      preferred: optional<boolean>
+  RequestGroup:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      replaces: optional<list<Reference>>
+      groupIdentifier: optional<Identifier>
+      status: optional<code>
+      intent: optional<code>
+      priority: optional<code>
+      code: optional<CodeableConcept>
+      subject: optional<Reference>
+      encounter: optional<Reference>
+      authoredOn: optional<dateTime>
+      author: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      action: optional<list<RequestGroup_Action>>
+  RequestGroup_Action:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      prefix: optional<string>
+      title: optional<string>
+      description: optional<string>
+      textEquivalent: optional<string>
+      priority: optional<code>
+      code: optional<list<CodeableConcept>>
+      documentation: optional<list<RelatedArtifact>>
+      condition: optional<list<RequestGroup_Condition>>
+      relatedAction: optional<list<RequestGroup_RelatedAction>>
+      timingDateTime: optional<string>
+      timingAge: optional<Age>
+      timingPeriod: optional<Period>
+      timingDuration: optional<Duration>
+      timingRange: optional<Range>
+      timingTiming: optional<Timing>
+      participant: optional<list<Reference>>
+      type: optional<CodeableConcept>
+      groupingBehavior: optional<code>
+      selectionBehavior: optional<code>
+      requiredBehavior: optional<code>
+      precheckBehavior: optional<code>
+      cardinalityBehavior: optional<code>
+      resource: optional<Reference>
+      action: optional<list<RequestGroup_Action>>
+  RequestGroup_Condition:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      kind: optional<code>
+      expression: optional<Expression>
+  RequestGroup_RelatedAction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      actionId: optional<id>
+      relationship: optional<code>
+      offsetDuration: optional<Duration>
+      offsetRange: optional<Range>
+  ResearchdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ResearchDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      shortTitle: optional<string>
+      subtitle: optional<string>
+      status: optional<ResearchdefinitionStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      comment: optional<list<string>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      library: optional<list<canonical>>
+      population: Reference
+      exposure: optional<Reference>
+      exposureAlternative: optional<Reference>
+      outcome: optional<Reference>
+  ResearchelementdefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ResearchelementdefinitionType:
+    enum:
+      - population
+      - exposure
+      - outcome
+  ResearchelementdefinitionVariabletype:
+    enum:
+      - dichotomous
+      - continuous
+      - descriptive
+  ResearchElementDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      shortTitle: optional<string>
+      subtitle: optional<string>
+      status: optional<ResearchelementdefinitionStatus>
+      experimental: optional<boolean>
+      subjectCodeableConcept: optional<CodeableConcept>
+      subjectReference: optional<Reference>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      comment: optional<list<string>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      usage: optional<string>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      library: optional<list<canonical>>
+      type: optional<ResearchelementdefinitionType>
+      variableType: optional<ResearchelementdefinitionVariabletype>
+      characteristic: list<ResearchElementDefinition_Characteristic>
+  Researchelementdefinition_characteristicStudyeffectivegroupmeasure:
+    enum:
+      - mean
+      - median
+      # - mean-of-mean
+      # - mean-of-median
+      # - median-of-mean
+      # - median-of-median
+  Researchelementdefinition_characteristicParticipanteffectivegroupmeasure:
+    enum:
+      - mean
+      - median
+      # - mean-of-mean
+      # - mean-of-median
+      # - median-of-mean
+      # - median-of-median
+  ResearchElementDefinition_Characteristic:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      definitionCodeableConcept: optional<CodeableConcept>
+      definitionCanonical: optional<string>
+      definitionExpression: optional<Expression>
+      definitionDataRequirement: optional<DataRequirement>
+      usageContext: optional<list<UsageContext>>
+      exclude: optional<boolean>
+      unitOfMeasure: optional<CodeableConcept>
+      studyEffectiveDescription: optional<string>
+      studyEffectiveDateTime: optional<string>
+      studyEffectivePeriod: optional<Period>
+      studyEffectiveDuration: optional<Duration>
+      studyEffectiveTiming: optional<Timing>
+      studyEffectiveTimeFromStart: optional<Duration>
+      studyEffectiveGroupMeasure: >-
+        optional<Researchelementdefinition_characteristicStudyeffectivegroupmeasure>
+      participantEffectiveDescription: optional<string>
+      participantEffectiveDateTime: optional<string>
+      participantEffectivePeriod: optional<Period>
+      participantEffectiveDuration: optional<Duration>
+      participantEffectiveTiming: optional<Timing>
+      participantEffectiveTimeFromStart: optional<Duration>
+      participantEffectiveGroupMeasure: >-
+        optional<Researchelementdefinition_characteristicParticipanteffectivegroupmeasure>
+  ResearchstudyStatus:
+    enum:
+      - active
+      # - administratively-completed
+      - approved
+      # - closed-to-accrual
+      # - closed-to-accrual-and-intervention
+      - completed
+      - disapproved
+      # - in-review
+      # - temporarily-closed-to-accrual
+      # - temporarily-closed-to-accrual-and-intervention
+      - withdrawn
+  ResearchStudy:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      title: optional<string>
+      protocol: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<ResearchstudyStatus>
+      primaryPurposeType: optional<CodeableConcept>
+      phase: optional<CodeableConcept>
+      category: optional<list<CodeableConcept>>
+      focus: optional<list<CodeableConcept>>
+      condition: optional<list<CodeableConcept>>
+      contact: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      keyword: optional<list<CodeableConcept>>
+      location: optional<list<CodeableConcept>>
+      description: optional<markdown>
+      enrollment: optional<list<Reference>>
+      period: optional<Period>
+      sponsor: optional<Reference>
+      principalInvestigator: optional<Reference>
+      site: optional<list<Reference>>
+      reasonStopped: optional<CodeableConcept>
+      note: optional<list<Annotation>>
+      arm: optional<list<ResearchStudy_Arm>>
+      objective: optional<list<ResearchStudy_Objective>>
+  ResearchStudy_Arm:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      type: optional<CodeableConcept>
+      description: optional<string>
+  ResearchStudy_Objective:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      type: optional<CodeableConcept>
+  ResearchsubjectStatus:
+    enum:
+      - candidate
+      - eligible
+      # - follow-up
+      - ineligible
+      # - not-registered
+      # - off-study
+      # - on-study
+      # - on-study-intervention
+      # - on-study-observation
+      # - pending-on-study
+      # - potential-candidate
+      - screening
+      - withdrawn
+  ResearchSubject:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<ResearchsubjectStatus>
+      period: optional<Period>
+      study: Reference
+      individual: Reference
+      assignedArm: optional<string>
+      actualArm: optional<string>
+      consent: optional<Reference>
+  RiskAssessment:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<Reference>
+      parent: optional<Reference>
+      status: optional<code>
+      method: optional<CodeableConcept>
+      code: optional<CodeableConcept>
+      subject: Reference
+      encounter: optional<Reference>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      condition: optional<Reference>
+      performer: optional<Reference>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      basis: optional<list<Reference>>
+      prediction: optional<list<RiskAssessment_Prediction>>
+      mitigation: optional<string>
+      note: optional<list<Annotation>>
+  RiskAssessment_Prediction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      outcome: optional<CodeableConcept>
+      probabilityDecimal: optional<double>
+      probabilityRange: optional<Range>
+      qualitativeRisk: optional<CodeableConcept>
+      relativeRisk: optional<decimal>
+      whenPeriod: optional<Period>
+      whenRange: optional<Range>
+      rationale: optional<string>
+  RiskevidencesynthesisStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  RiskEvidenceSynthesis:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<RiskevidencesynthesisStatus>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      note: optional<list<Annotation>>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      copyright: optional<markdown>
+      approvalDate: optional<date>
+      lastReviewDate: optional<date>
+      effectivePeriod: optional<Period>
+      topic: optional<list<CodeableConcept>>
+      author: optional<list<ContactDetail>>
+      editor: optional<list<ContactDetail>>
+      reviewer: optional<list<ContactDetail>>
+      endorser: optional<list<ContactDetail>>
+      relatedArtifact: optional<list<RelatedArtifact>>
+      synthesisType: optional<CodeableConcept>
+      studyType: optional<CodeableConcept>
+      population: Reference
+      exposure: optional<Reference>
+      outcome: Reference
+      sampleSize: optional<RiskEvidenceSynthesis_SampleSize>
+      riskEstimate: optional<RiskEvidenceSynthesis_RiskEstimate>
+      certainty: optional<list<RiskEvidenceSynthesis_Certainty>>
+  RiskEvidenceSynthesis_SampleSize:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      numberOfStudies: optional<integer>
+      numberOfParticipants: optional<integer>
+  RiskEvidenceSynthesis_RiskEstimate:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      type: optional<CodeableConcept>
+      value: optional<decimal>
+      unitOfMeasure: optional<CodeableConcept>
+      denominatorCount: optional<integer>
+      numeratorCount: optional<integer>
+      precisionEstimate: optional<list<RiskEvidenceSynthesis_PrecisionEstimate>>
+  RiskEvidenceSynthesis_PrecisionEstimate:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      level: optional<decimal>
+      from: optional<decimal>
+      to: optional<decimal>
+  RiskEvidenceSynthesis_Certainty:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      rating: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+      certaintySubcomponent: optional<list<RiskEvidenceSynthesis_CertaintySubcomponent>>
+  RiskEvidenceSynthesis_CertaintySubcomponent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      rating: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+  Schedule:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      active: optional<boolean>
+      serviceCategory: optional<list<CodeableConcept>>
+      serviceType: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      actor: list<Reference>
+      planningHorizon: optional<Period>
+      comment: optional<string>
+  SearchparameterStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  SearchparameterType:
+    enum:
+      - number
+      - date
+      - string
+      - token
+      - reference
+      - composite
+      - quantity
+      - uri
+      - special
+  SearchparameterXpathusage:
+    enum:
+      - normal
+      - phonetic
+      - nearby
+      - distance
+      - other
+  SearchparameterComparatorItem:
+    enum:
+      - eq
+      - ne
+      - gt
+      - lt
+      - ge
+      - le
+      - sa
+      - eb
+      - ap
+  SearchparameterModifierItem:
+    enum:
+      - missing
+      - exact
+      - contains
+      - not
+      - text
+      - in
+      # - not-in
+      - below
+      - above
+      - type
+      - identifier
+      - ofType
+  SearchParameter:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      derivedFrom: optional<canonical>
+      status: optional<SearchparameterStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      code: optional<code>
+      base: optional<list<code>>
+      type: optional<SearchparameterType>
+      expression: optional<string>
+      xpath: optional<string>
+      xpathUsage: optional<SearchparameterXpathusage>
+      target: optional<list<code>>
+      multipleOr: optional<boolean>
+      multipleAnd: optional<boolean>
+      comparator: optional<list<SearchparameterComparatorItem>>
+      modifier: optional<list<SearchparameterModifierItem>>
+      chain: optional<list<string>>
+      component: optional<list<SearchParameter_Component>>
+  SearchParameter_Component:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      definition: canonical
+      expression: optional<string>
+  ServiceRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<list<canonical>>
+      instantiatesUri: optional<list<uri>>
+      basedOn: optional<list<Reference>>
+      replaces: optional<list<Reference>>
+      requisition: optional<Identifier>
+      status: optional<code>
+      intent: optional<code>
+      category: optional<list<CodeableConcept>>
+      priority: optional<code>
+      doNotPerform: optional<boolean>
+      code: optional<CodeableConcept>
+      orderDetail: optional<list<CodeableConcept>>
+      quantityQuantity: optional<Quantity>
+      quantityRatio: optional<Ratio>
+      quantityRange: optional<Range>
+      subject: Reference
+      encounter: optional<Reference>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      asNeededBoolean: optional<boolean>
+      asNeededCodeableConcept: optional<CodeableConcept>
+      authoredOn: optional<dateTime>
+      requester: optional<Reference>
+      performerType: optional<CodeableConcept>
+      performer: optional<list<Reference>>
+      locationCode: optional<list<CodeableConcept>>
+      locationReference: optional<list<Reference>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      insurance: optional<list<Reference>>
+      supportingInfo: optional<list<Reference>>
+      specimen: optional<list<Reference>>
+      bodySite: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+      patientInstruction: optional<string>
+      relevantHistory: optional<list<Reference>>
+  SlotStatus:
+    enum:
+      - busy
+      - free
+      # - busy-unavailable
+      # - busy-tentative
+      # - entered-in-error
+  Slot:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      serviceCategory: optional<list<CodeableConcept>>
+      serviceType: optional<list<CodeableConcept>>
+      specialty: optional<list<CodeableConcept>>
+      appointmentType: optional<CodeableConcept>
+      schedule: Reference
+      status: optional<SlotStatus>
+      start: optional<instant>
+      end: optional<instant>
+      overbooked: optional<boolean>
+      comment: optional<string>
+  SpecimenStatus:
+    enum:
+      - available
+      - unavailable
+      - unsatisfactory
+      # - entered-in-error
+  Specimen:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      accessionIdentifier: optional<Identifier>
+      status: optional<SpecimenStatus>
+      type: optional<CodeableConcept>
+      subject: optional<Reference>
+      receivedTime: optional<dateTime>
+      parent: optional<list<Reference>>
+      request: optional<list<Reference>>
+      collection: optional<Specimen_Collection>
+      processing: optional<list<Specimen_Processing>>
+      container: optional<list<Specimen_Container>>
+      condition: optional<list<CodeableConcept>>
+      note: optional<list<Annotation>>
+  Specimen_Collection:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      collector: optional<Reference>
+      collectedDateTime: optional<string>
+      collectedPeriod: optional<Period>
+      duration: optional<Duration>
+      quantity: optional<Quantity>
+      method: optional<CodeableConcept>
+      bodySite: optional<CodeableConcept>
+      fastingStatusCodeableConcept: optional<CodeableConcept>
+      fastingStatusDuration: optional<Duration>
+  Specimen_Processing:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      procedure: optional<CodeableConcept>
+      additive: optional<list<Reference>>
+      timeDateTime: optional<string>
+      timePeriod: optional<Period>
+  Specimen_Container:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      description: optional<string>
+      type: optional<CodeableConcept>
+      capacity: optional<Quantity>
+      specimenQuantity: optional<Quantity>
+      additiveCodeableConcept: optional<CodeableConcept>
+      additiveReference: optional<Reference>
+  SpecimenDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      typeCollected: optional<CodeableConcept>
+      patientPreparation: optional<list<CodeableConcept>>
+      timeAspect: optional<string>
+      collection: optional<list<CodeableConcept>>
+      typeTested: optional<list<SpecimenDefinition_TypeTested>>
+  Specimendefinition_typetestedPreference:
+    enum:
+      - preferred
+      - alternate
+  SpecimenDefinition_TypeTested:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      isDerived: optional<boolean>
+      type: optional<CodeableConcept>
+      preference: optional<Specimendefinition_typetestedPreference>
+      container: optional<SpecimenDefinition_Container>
+      requirement: optional<string>
+      retentionTime: optional<Duration>
+      rejectionCriterion: optional<list<CodeableConcept>>
+      handling: optional<list<SpecimenDefinition_Handling>>
+  SpecimenDefinition_Container:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      material: optional<CodeableConcept>
+      type: optional<CodeableConcept>
+      cap: optional<CodeableConcept>
+      description: optional<string>
+      capacity: optional<Quantity>
+      minimumVolumeQuantity: optional<Quantity>
+      minimumVolumeString: optional<string>
+      additive: optional<list<SpecimenDefinition_Additive>>
+      preparation: optional<string>
+  SpecimenDefinition_Additive:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      additiveCodeableConcept: optional<CodeableConcept>
+      additiveReference: optional<Reference>
+  SpecimenDefinition_Handling:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      temperatureQualifier: optional<CodeableConcept>
+      temperatureRange: optional<Range>
+      maxDuration: optional<Duration>
+      instruction: optional<string>
+  StructuredefinitionStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  StructuredefinitionFhirversion:
+    enum:
+      []
+      # - "0.01"
+      # - "0.05"
+      # - "0.06"
+      # - "0.11"
+      # - 0.0.80
+      # - 0.0.81
+      # - 0.0.82
+      # - 0.4.0
+      # - 0.5.0
+      # - 1.0.0
+      # - 1.0.1
+      # - 1.0.2
+      # - 1.1.0
+      # - 1.4.0
+      # - 1.6.0
+      # - 1.8.0
+      # - 3.0.0
+      # - 3.0.1
+      # - 3.3.0
+      # - 3.5.0
+      # - 4.0.0
+      # - 4.0.1
+  StructuredefinitionKind:
+    enum:
+      # - primitive-type
+      # - complex-type
+      - resource
+      - logical
+  StructuredefinitionDerivation:
+    enum:
+      - specialization
+      - constraint
+  StructureDefinition:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<StructuredefinitionStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      keyword: optional<list<Coding>>
+      fhirVersion: optional<StructuredefinitionFhirversion>
+      mapping: optional<list<StructureDefinition_Mapping>>
+      kind: optional<StructuredefinitionKind>
+      abstract: optional<boolean>
+      context: optional<list<StructureDefinition_Context>>
+      contextInvariant: optional<list<string>>
+      type: optional<uri>
+      baseDefinition: optional<canonical>
+      derivation: optional<StructuredefinitionDerivation>
+      snapshot: optional<StructureDefinition_Snapshot>
+      differential: optional<StructureDefinition_Differential>
+  StructureDefinition_Mapping:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identity: optional<id>
+      uri: optional<uri>
+      name: optional<string>
+      comment: optional<string>
+  Structuredefinition_contextType:
+    enum:
+      - fhirpath
+      - element
+      - extension
+  StructureDefinition_Context:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Structuredefinition_contextType>
+      expression: optional<string>
+  StructureDefinition_Snapshot:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      element: list<ElementDefinition>
+  StructureDefinition_Differential:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      element: list<ElementDefinition>
+  StructuremapStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  StructureMap:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<StructuremapStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      structure: optional<list<StructureMap_Structure>>
+      import: optional<list<canonical>>
+      group: list<StructureMap_Group>
+  Structuremap_structureMode:
+    enum:
+      - source
+      - queried
+      - target
+      - produced
+  StructureMap_Structure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: canonical
+      mode: optional<Structuremap_structureMode>
+      alias: optional<string>
+      documentation: optional<string>
+  Structuremap_groupTypemode:
+    enum:
+      - none
+      - types
+      # - type-and-types
+  StructureMap_Group:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<id>
+      extends: optional<id>
+      typeMode: optional<Structuremap_groupTypemode>
+      documentation: optional<string>
+      input: list<StructureMap_Input>
+      rule: list<StructureMap_Rule>
+  Structuremap_inputMode:
+    enum:
+      - source
+      - target
+  StructureMap_Input:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<id>
+      type: optional<string>
+      mode: optional<Structuremap_inputMode>
+      documentation: optional<string>
+  StructureMap_Rule:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<id>
+      source: list<StructureMap_Source>
+      target: optional<list<StructureMap_Target>>
+      rule: optional<list<StructureMap_Rule>>
+      dependent: optional<list<StructureMap_Dependent>>
+      documentation: optional<string>
+  Structuremap_sourceListmode:
+    enum:
+      - first
+      # - not_first
+      - last
+      # - not_last
+      # - only_one
+  StructureMap_Source:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      context: optional<id>
+      min: optional<integer>
+      max: optional<string>
+      type: optional<string>
+      defaultValueBase64Binary: optional<string>
+      defaultValueBoolean: optional<boolean>
+      defaultValueCanonical: optional<string>
+      defaultValueCode: optional<string>
+      defaultValueDate: optional<string>
+      defaultValueDateTime: optional<string>
+      defaultValueDecimal: optional<double>
+      defaultValueId: optional<string>
+      defaultValueInstant: optional<string>
+      defaultValueInteger: optional<double>
+      defaultValueMarkdown: optional<string>
+      defaultValueOid: optional<string>
+      defaultValuePositiveInt: optional<double>
+      defaultValueString: optional<string>
+      defaultValueTime: optional<string>
+      defaultValueUnsignedInt: optional<double>
+      defaultValueUri: optional<string>
+      defaultValueUrl: optional<string>
+      defaultValueUuid: optional<string>
+      defaultValueAddress: optional<Address>
+      defaultValueAge: optional<Age>
+      defaultValueAnnotation: optional<Annotation>
+      defaultValueAttachment: optional<Attachment>
+      defaultValueCodeableConcept: optional<CodeableConcept>
+      defaultValueCoding: optional<Coding>
+      defaultValueContactPoint: optional<ContactPoint>
+      defaultValueCount: optional<Count>
+      defaultValueDistance: optional<Distance>
+      defaultValueDuration: optional<Duration>
+      defaultValueHumanName: optional<HumanName>
+      defaultValueIdentifier: optional<Identifier>
+      defaultValueMoney: optional<Money>
+      defaultValuePeriod: optional<Period>
+      defaultValueQuantity: optional<Quantity>
+      defaultValueRange: optional<Range>
+      defaultValueRatio: optional<Ratio>
+      defaultValueReference: optional<Reference>
+      defaultValueSampledData: optional<SampledData>
+      defaultValueSignature: optional<Signature>
+      defaultValueTiming: optional<Timing>
+      defaultValueContactDetail: optional<ContactDetail>
+      defaultValueContributor: optional<Contributor>
+      defaultValueDataRequirement: optional<DataRequirement>
+      defaultValueExpression: optional<Expression>
+      defaultValueParameterDefinition: optional<ParameterDefinition>
+      defaultValueRelatedArtifact: optional<RelatedArtifact>
+      defaultValueTriggerDefinition: optional<TriggerDefinition>
+      defaultValueUsageContext: optional<UsageContext>
+      defaultValueDosage: optional<Dosage>
+      defaultValueMeta: optional<Meta>
+      element: optional<string>
+      listMode: optional<Structuremap_sourceListmode>
+      variable: optional<id>
+      condition: optional<string>
+      check: optional<string>
+      logMessage: optional<string>
+  Structuremap_targetContexttype:
+    enum:
+      - type
+      - variable
+  Structuremap_targetListmodeItem:
+    enum:
+      - first
+      - share
+      - last
+      - collate
+  Structuremap_targetTransform:
+    enum:
+      - create
+      - copy
+      - truncate
+      - escape
+      - cast
+      - append
+      - translate
+      - reference
+      - dateOp
+      - uuid
+      - pointer
+      - evaluate
+      - cc
+      - c
+      - qty
+      - id
+      - cp
+  StructureMap_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      context: optional<id>
+      contextType: optional<Structuremap_targetContexttype>
+      element: optional<string>
+      variable: optional<id>
+      listMode: optional<list<Structuremap_targetListmodeItem>>
+      listRuleId: optional<id>
+      transform: optional<Structuremap_targetTransform>
+      parameter: optional<list<StructureMap_Parameter>>
+  StructureMap_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      valueId: optional<string>
+      valueString: optional<string>
+      valueBoolean: optional<boolean>
+      valueInteger: optional<double>
+      valueDecimal: optional<double>
+  StructureMap_Dependent:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<id>
+      variable: optional<list<string>>
+  SubscriptionStatus:
+    enum:
+      - requested
+      - active
+      - error
+      - "off"
+  Subscription:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      status: optional<SubscriptionStatus>
+      contact: optional<list<ContactPoint>>
+      end: optional<instant>
+      reason: optional<string>
+      criteria: optional<string>
+      error: optional<string>
+      channel: Subscription_Channel
+  Subscription_channelType:
+    enum:
+      # - rest-hook
+      - websocket
+      - email
+      - sms
+      - message
+  Subscription_Channel:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Subscription_channelType>
+      endpoint: optional<url>
+      payload: optional<code>
+      header: optional<list<string>>
+  SubstanceStatus:
+    enum:
+      - active
+      - inactive
+      # - entered-in-error
+  Substance:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<SubstanceStatus>
+      category: optional<list<CodeableConcept>>
+      code: CodeableConcept
+      description: optional<string>
+      instance: optional<list<Substance_Instance>>
+      ingredient: optional<list<Substance_Ingredient>>
+  Substance_Instance:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      expiry: optional<dateTime>
+      quantity: optional<Quantity>
+  Substance_Ingredient:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      quantity: optional<Ratio>
+      substanceCodeableConcept: optional<CodeableConcept>
+      substanceReference: optional<Reference>
+  SubstanceNucleicAcid:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequenceType: optional<CodeableConcept>
+      numberOfSubunits: optional<integer>
+      areaOfHybridisation: optional<string>
+      oligoNucleotideType: optional<CodeableConcept>
+      subunit: optional<list<SubstanceNucleicAcid_Subunit>>
+  SubstanceNucleicAcid_Subunit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subunit: optional<integer>
+      sequence: optional<string>
+      length: optional<integer>
+      sequenceAttachment: optional<Attachment>
+      fivePrime: optional<CodeableConcept>
+      threePrime: optional<CodeableConcept>
+      linkage: optional<list<SubstanceNucleicAcid_Linkage>>
+      sugar: optional<list<SubstanceNucleicAcid_Sugar>>
+  SubstanceNucleicAcid_Linkage:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      connectivity: optional<string>
+      identifier: optional<Identifier>
+      name: optional<string>
+      residueSite: optional<string>
+  SubstanceNucleicAcid_Sugar:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      name: optional<string>
+      residueSite: optional<string>
+  SubstancePolymer:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      class: optional<CodeableConcept>
+      geometry: optional<CodeableConcept>
+      copolymerConnectivity: optional<list<CodeableConcept>>
+      modification: optional<list<string>>
+      monomerSet: optional<list<SubstancePolymer_MonomerSet>>
+      repeat: optional<list<SubstancePolymer_Repeat>>
+  SubstancePolymer_MonomerSet:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      ratioType: optional<CodeableConcept>
+      startingMaterial: optional<list<SubstancePolymer_StartingMaterial>>
+  SubstancePolymer_StartingMaterial:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      material: optional<CodeableConcept>
+      type: optional<CodeableConcept>
+      isDefining: optional<boolean>
+      amount: optional<SubstanceAmount>
+  SubstancePolymer_Repeat:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      numberOfUnits: optional<integer>
+      averageMolecularFormula: optional<string>
+      repeatUnitAmountType: optional<CodeableConcept>
+      repeatUnit: optional<list<SubstancePolymer_RepeatUnit>>
+  SubstancePolymer_RepeatUnit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      orientationOfPolymerisation: optional<CodeableConcept>
+      repeatUnit: optional<string>
+      amount: optional<SubstanceAmount>
+      degreeOfPolymerisation: optional<list<SubstancePolymer_DegreeOfPolymerisation>>
+      structuralRepresentation: optional<list<SubstancePolymer_StructuralRepresentation>>
+  SubstancePolymer_DegreeOfPolymerisation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      degree: optional<CodeableConcept>
+      amount: optional<SubstanceAmount>
+  SubstancePolymer_StructuralRepresentation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      representation: optional<string>
+      attachment: optional<Attachment>
+  SubstanceProtein:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sequenceType: optional<CodeableConcept>
+      numberOfSubunits: optional<integer>
+      disulfideLinkage: optional<list<string>>
+      subunit: optional<list<SubstanceProtein_Subunit>>
+  SubstanceProtein_Subunit:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      subunit: optional<integer>
+      sequence: optional<string>
+      length: optional<integer>
+      sequenceAttachment: optional<Attachment>
+      nTerminalModificationId: optional<Identifier>
+      nTerminalModification: optional<string>
+      cTerminalModificationId: optional<Identifier>
+      cTerminalModification: optional<string>
+  SubstanceReferenceInformation:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      comment: optional<string>
+      gene: optional<list<SubstanceReferenceInformation_Gene>>
+      geneElement: optional<list<SubstanceReferenceInformation_GeneElement>>
+      classification: optional<list<SubstanceReferenceInformation_Classification>>
+      target: optional<list<SubstanceReferenceInformation_Target>>
+  SubstanceReferenceInformation_Gene:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      geneSequenceOrigin: optional<CodeableConcept>
+      gene: optional<CodeableConcept>
+      source: optional<list<Reference>>
+  SubstanceReferenceInformation_GeneElement:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      element: optional<Identifier>
+      source: optional<list<Reference>>
+  SubstanceReferenceInformation_Classification:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      domain: optional<CodeableConcept>
+      classification: optional<CodeableConcept>
+      subtype: optional<list<CodeableConcept>>
+      source: optional<list<Reference>>
+  SubstanceReferenceInformation_Target:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      target: optional<Identifier>
+      type: optional<CodeableConcept>
+      interaction: optional<CodeableConcept>
+      organism: optional<CodeableConcept>
+      organismType: optional<CodeableConcept>
+      amountQuantity: optional<Quantity>
+      amountRange: optional<Range>
+      amountString: optional<string>
+      amountType: optional<CodeableConcept>
+      source: optional<list<Reference>>
+  SubstanceSourceMaterial:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      sourceMaterialClass: optional<CodeableConcept>
+      sourceMaterialType: optional<CodeableConcept>
+      sourceMaterialState: optional<CodeableConcept>
+      organismId: optional<Identifier>
+      organismName: optional<string>
+      parentSubstanceId: optional<list<Identifier>>
+      parentSubstanceName: optional<list<string>>
+      countryOfOrigin: optional<list<CodeableConcept>>
+      geographicalLocation: optional<list<string>>
+      developmentStage: optional<CodeableConcept>
+      fractionDescription: optional<list<SubstanceSourceMaterial_FractionDescription>>
+      organism: optional<SubstanceSourceMaterial_Organism>
+      partDescription: optional<list<SubstanceSourceMaterial_PartDescription>>
+  SubstanceSourceMaterial_FractionDescription:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      fraction: optional<string>
+      materialType: optional<CodeableConcept>
+  SubstanceSourceMaterial_Organism:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      family: optional<CodeableConcept>
+      genus: optional<CodeableConcept>
+      species: optional<CodeableConcept>
+      intraspecificType: optional<CodeableConcept>
+      intraspecificDescription: optional<string>
+      author: optional<list<SubstanceSourceMaterial_Author>>
+      hybrid: optional<SubstanceSourceMaterial_Hybrid>
+      organismGeneral: optional<SubstanceSourceMaterial_OrganismGeneral>
+  SubstanceSourceMaterial_Author:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      authorType: optional<CodeableConcept>
+      authorDescription: optional<string>
+  SubstanceSourceMaterial_Hybrid:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      maternalOrganismId: optional<string>
+      maternalOrganismName: optional<string>
+      paternalOrganismId: optional<string>
+      paternalOrganismName: optional<string>
+      hybridType: optional<CodeableConcept>
+  SubstanceSourceMaterial_OrganismGeneral:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      kingdom: optional<CodeableConcept>
+      phylum: optional<CodeableConcept>
+      class: optional<CodeableConcept>
+      order: optional<CodeableConcept>
+  SubstanceSourceMaterial_PartDescription:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      part: optional<CodeableConcept>
+      partLocation: optional<CodeableConcept>
+  SubstanceSpecification:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      type: optional<CodeableConcept>
+      status: optional<CodeableConcept>
+      domain: optional<CodeableConcept>
+      description: optional<string>
+      source: optional<list<Reference>>
+      comment: optional<string>
+      moiety: optional<list<SubstanceSpecification_Moiety>>
+      property: optional<list<SubstanceSpecification_Property>>
+      referenceInformation: optional<Reference>
+      structure: optional<SubstanceSpecification_Structure>
+      code: optional<list<SubstanceSpecification_Code>>
+      name: optional<list<SubstanceSpecification_Name>>
+      molecularWeight: optional<list<SubstanceSpecification_MolecularWeight>>
+      relationship: optional<list<SubstanceSpecification_Relationship>>
+      nucleicAcid: optional<Reference>
+      polymer: optional<Reference>
+      protein: optional<Reference>
+      sourceMaterial: optional<Reference>
+  SubstanceSpecification_Moiety:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      role: optional<CodeableConcept>
+      identifier: optional<Identifier>
+      name: optional<string>
+      stereochemistry: optional<CodeableConcept>
+      opticalActivity: optional<CodeableConcept>
+      molecularFormula: optional<string>
+      amountQuantity: optional<Quantity>
+      amountString: optional<string>
+  SubstanceSpecification_Property:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      category: optional<CodeableConcept>
+      code: optional<CodeableConcept>
+      parameters: optional<string>
+      definingSubstanceReference: optional<Reference>
+      definingSubstanceCodeableConcept: optional<CodeableConcept>
+      amountQuantity: optional<Quantity>
+      amountString: optional<string>
+  SubstanceSpecification_Structure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      stereochemistry: optional<CodeableConcept>
+      opticalActivity: optional<CodeableConcept>
+      molecularFormula: optional<string>
+      molecularFormulaByMoiety: optional<string>
+      isotope: optional<list<SubstanceSpecification_Isotope>>
+      molecularWeight: optional<SubstanceSpecification_MolecularWeight>
+      source: optional<list<Reference>>
+      representation: optional<list<SubstanceSpecification_Representation>>
+  SubstanceSpecification_Isotope:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      name: optional<CodeableConcept>
+      substitution: optional<CodeableConcept>
+      halfLife: optional<Quantity>
+      molecularWeight: optional<SubstanceSpecification_MolecularWeight>
+  SubstanceSpecification_MolecularWeight:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      method: optional<CodeableConcept>
+      type: optional<CodeableConcept>
+      amount: optional<Quantity>
+  SubstanceSpecification_Representation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<CodeableConcept>
+      representation: optional<string>
+      attachment: optional<Attachment>
+  SubstanceSpecification_Code:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      status: optional<CodeableConcept>
+      statusDate: optional<dateTime>
+      comment: optional<string>
+      source: optional<list<Reference>>
+  SubstanceSpecification_Name:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      type: optional<CodeableConcept>
+      status: optional<CodeableConcept>
+      preferred: optional<boolean>
+      language: optional<list<CodeableConcept>>
+      domain: optional<list<CodeableConcept>>
+      jurisdiction: optional<list<CodeableConcept>>
+      synonym: optional<list<SubstanceSpecification_Name>>
+      translation: optional<list<SubstanceSpecification_Name>>
+      official: optional<list<SubstanceSpecification_Official>>
+      source: optional<list<Reference>>
+  SubstanceSpecification_Official:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      authority: optional<CodeableConcept>
+      status: optional<CodeableConcept>
+      date: optional<dateTime>
+  SubstanceSpecification_Relationship:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      substanceReference: optional<Reference>
+      substanceCodeableConcept: optional<CodeableConcept>
+      relationship: optional<CodeableConcept>
+      isDefining: optional<boolean>
+      amountQuantity: optional<Quantity>
+      amountRange: optional<Range>
+      amountRatio: optional<Ratio>
+      amountString: optional<string>
+      amountRatioLowLimit: optional<Ratio>
+      amountType: optional<CodeableConcept>
+      source: optional<list<Reference>>
+  SupplydeliveryStatus:
+    enum:
+      # - in-progress
+      - completed
+      - abandoned
+      # - entered-in-error
+  SupplyDelivery:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      basedOn: optional<list<Reference>>
+      partOf: optional<list<Reference>>
+      status: optional<SupplydeliveryStatus>
+      patient: optional<Reference>
+      type: optional<CodeableConcept>
+      suppliedItem: optional<SupplyDelivery_SuppliedItem>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      supplier: optional<Reference>
+      destination: optional<Reference>
+      receiver: optional<list<Reference>>
+  SupplyDelivery_SuppliedItem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      quantity: optional<Quantity>
+      itemCodeableConcept: optional<CodeableConcept>
+      itemReference: optional<Reference>
+  SupplyrequestStatus:
+    enum:
+      - draft
+      - active
+      - suspended
+      - cancelled
+      - completed
+      # - entered-in-error
+      - unknown
+  SupplyRequest:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<SupplyrequestStatus>
+      category: optional<CodeableConcept>
+      priority: optional<code>
+      itemCodeableConcept: optional<CodeableConcept>
+      itemReference: optional<Reference>
+      quantity: Quantity
+      parameter: optional<list<SupplyRequest_Parameter>>
+      occurrenceDateTime: optional<string>
+      occurrencePeriod: optional<Period>
+      occurrenceTiming: optional<Timing>
+      authoredOn: optional<dateTime>
+      requester: optional<Reference>
+      supplier: optional<list<Reference>>
+      reasonCode: optional<list<CodeableConcept>>
+      reasonReference: optional<list<Reference>>
+      deliverFrom: optional<Reference>
+      deliverTo: optional<Reference>
+  SupplyRequest_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<CodeableConcept>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueBoolean: optional<boolean>
+  TaskStatus:
+    enum:
+      - draft
+      - requested
+      - received
+      - accepted
+      - rejected
+      - ready
+      - cancelled
+      - in-progress
+      - on-hold
+      - failed
+      - completed
+      # - entered-in-error
+  TaskIntent:
+    enum:
+      - unknown
+      - proposal
+      - plan
+      - order
+      # - original-order
+      # - reflex-order
+      # - filler-order
+      # - instance-order
+      - option
+  Task:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      instantiatesCanonical: optional<canonical>
+      instantiatesUri: optional<uri>
+      basedOn: optional<list<Reference>>
+      groupIdentifier: optional<Identifier>
+      partOf: optional<list<Reference>>
+      status: optional<TaskStatus>
+      statusReason: optional<CodeableConcept>
+      businessStatus: optional<CodeableConcept>
+      intent: optional<TaskIntent>
+      priority: optional<code>
+      code: optional<CodeableConcept>
+      description: optional<string>
+      focus: optional<Reference>
+      for: optional<Reference>
+      encounter: optional<Reference>
+      executionPeriod: optional<Period>
+      authoredOn: optional<dateTime>
+      lastModified: optional<dateTime>
+      requester: optional<Reference>
+      performerType: optional<list<CodeableConcept>>
+      owner: optional<Reference>
+      location: optional<Reference>
+      reasonCode: optional<CodeableConcept>
+      reasonReference: optional<Reference>
+      insurance: optional<list<Reference>>
+      note: optional<list<Annotation>>
+      relevantHistory: optional<list<Reference>>
+      restriction: optional<Task_Restriction>
+      input: optional<list<Task_Input>>
+      output: optional<list<Task_Output>>
+  Task_Restriction:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      repetitions: optional<positiveInt>
+      period: optional<Period>
+      recipient: optional<list<Reference>>
+  Task_Input:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      valueBase64Binary: optional<string>
+      valueBoolean: optional<boolean>
+      valueCanonical: optional<string>
+      valueCode: optional<string>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+      valueId: optional<string>
+      valueInstant: optional<string>
+      valueInteger: optional<double>
+      valueMarkdown: optional<string>
+      valueOid: optional<string>
+      valuePositiveInt: optional<double>
+      valueString: optional<string>
+      valueTime: optional<string>
+      valueUnsignedInt: optional<double>
+      valueUri: optional<string>
+      valueUrl: optional<string>
+      valueUuid: optional<string>
+      valueAddress: optional<Address>
+      valueAge: optional<Age>
+      valueAnnotation: optional<Annotation>
+      valueAttachment: optional<Attachment>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueCoding: optional<Coding>
+      valueContactPoint: optional<ContactPoint>
+      valueCount: optional<Count>
+      valueDistance: optional<Distance>
+      valueDuration: optional<Duration>
+      valueHumanName: optional<HumanName>
+      valueIdentifier: optional<Identifier>
+      valueMoney: optional<Money>
+      valuePeriod: optional<Period>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueReference: optional<Reference>
+      valueSampledData: optional<SampledData>
+      valueSignature: optional<Signature>
+      valueTiming: optional<Timing>
+      valueContactDetail: optional<ContactDetail>
+      valueContributor: optional<Contributor>
+      valueDataRequirement: optional<DataRequirement>
+      valueExpression: optional<Expression>
+      valueParameterDefinition: optional<ParameterDefinition>
+      valueRelatedArtifact: optional<RelatedArtifact>
+      valueTriggerDefinition: optional<TriggerDefinition>
+      valueUsageContext: optional<UsageContext>
+      valueDosage: optional<Dosage>
+      valueMeta: optional<Meta>
+  Task_Output:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: CodeableConcept
+      valueBase64Binary: optional<string>
+      valueBoolean: optional<boolean>
+      valueCanonical: optional<string>
+      valueCode: optional<string>
+      valueDate: optional<string>
+      valueDateTime: optional<string>
+      valueDecimal: optional<double>
+      valueId: optional<string>
+      valueInstant: optional<string>
+      valueInteger: optional<double>
+      valueMarkdown: optional<string>
+      valueOid: optional<string>
+      valuePositiveInt: optional<double>
+      valueString: optional<string>
+      valueTime: optional<string>
+      valueUnsignedInt: optional<double>
+      valueUri: optional<string>
+      valueUrl: optional<string>
+      valueUuid: optional<string>
+      valueAddress: optional<Address>
+      valueAge: optional<Age>
+      valueAnnotation: optional<Annotation>
+      valueAttachment: optional<Attachment>
+      valueCodeableConcept: optional<CodeableConcept>
+      valueCoding: optional<Coding>
+      valueContactPoint: optional<ContactPoint>
+      valueCount: optional<Count>
+      valueDistance: optional<Distance>
+      valueDuration: optional<Duration>
+      valueHumanName: optional<HumanName>
+      valueIdentifier: optional<Identifier>
+      valueMoney: optional<Money>
+      valuePeriod: optional<Period>
+      valueQuantity: optional<Quantity>
+      valueRange: optional<Range>
+      valueRatio: optional<Ratio>
+      valueReference: optional<Reference>
+      valueSampledData: optional<SampledData>
+      valueSignature: optional<Signature>
+      valueTiming: optional<Timing>
+      valueContactDetail: optional<ContactDetail>
+      valueContributor: optional<Contributor>
+      valueDataRequirement: optional<DataRequirement>
+      valueExpression: optional<Expression>
+      valueParameterDefinition: optional<ParameterDefinition>
+      valueRelatedArtifact: optional<RelatedArtifact>
+      valueTriggerDefinition: optional<TriggerDefinition>
+      valueUsageContext: optional<UsageContext>
+      valueDosage: optional<Dosage>
+      valueMeta: optional<Meta>
+  TerminologycapabilitiesStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  TerminologycapabilitiesCodesearch:
+    enum:
+      - explicit
+      - all
+  TerminologyCapabilities:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<TerminologycapabilitiesStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      kind: optional<code>
+      software: optional<TerminologyCapabilities_Software>
+      implementation: optional<TerminologyCapabilities_Implementation>
+      lockedDate: optional<boolean>
+      codeSystem: optional<list<TerminologyCapabilities_CodeSystem>>
+      expansion: optional<TerminologyCapabilities_Expansion>
+      codeSearch: optional<TerminologycapabilitiesCodesearch>
+      validateCode: optional<TerminologyCapabilities_ValidateCode>
+      translation: optional<TerminologyCapabilities_Translation>
+      closure: optional<TerminologyCapabilities_Closure>
+  TerminologyCapabilities_Software:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      version: optional<string>
+  TerminologyCapabilities_Implementation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      description: optional<string>
+      url: optional<url>
+  TerminologyCapabilities_CodeSystem:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      uri: optional<canonical>
+      version: optional<list<TerminologyCapabilities_Version>>
+      subsumption: optional<boolean>
+  TerminologyCapabilities_Version:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<string>
+      isDefault: optional<boolean>
+      compositional: optional<boolean>
+      language: optional<list<code>>
+      filter: optional<list<TerminologyCapabilities_Filter>>
+      property: optional<list<code>>
+  TerminologyCapabilities_Filter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      op: optional<list<code>>
+  TerminologyCapabilities_Expansion:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      hierarchical: optional<boolean>
+      paging: optional<boolean>
+      incomplete: optional<boolean>
+      parameter: optional<list<TerminologyCapabilities_Parameter>>
+      textFilter: optional<markdown>
+  TerminologyCapabilities_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<code>
+      documentation: optional<string>
+  TerminologyCapabilities_ValidateCode:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      translations: optional<boolean>
+  TerminologyCapabilities_Translation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      needsMap: optional<boolean>
+  TerminologyCapabilities_Closure:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      translation: optional<boolean>
+  TestreportStatus:
+    enum:
+      - completed
+      # - in-progress
+      - waiting
+      - stopped
+      # - entered-in-error
+  TestreportResult:
+    enum:
+      - pass
+      - fail
+      - pending
+  TestReport:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<Identifier>
+      name: optional<string>
+      status: optional<TestreportStatus>
+      testScript: Reference
+      result: optional<TestreportResult>
+      score: optional<decimal>
+      tester: optional<string>
+      issued: optional<dateTime>
+      participant: optional<list<TestReport_Participant>>
+      setup: optional<TestReport_Setup>
+      test: optional<list<TestReport_Test>>
+      teardown: optional<TestReport_Teardown>
+  Testreport_participantType:
+    enum:
+      # - test-engine
+      - client
+      - server
+  TestReport_Participant:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Testreport_participantType>
+      uri: optional<uri>
+      display: optional<string>
+  TestReport_Setup:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: list<TestReport_Action>
+  TestReport_Action:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: optional<TestReport_Operation>
+      assert: optional<TestReport_Assert>
+  Testreport_operationResult:
+    enum:
+      - pass
+      - skip
+      - fail
+      - warning
+      - error
+  TestReport_Operation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      result: optional<Testreport_operationResult>
+      message: optional<markdown>
+      detail: optional<uri>
+  Testreport_assertResult:
+    enum:
+      - pass
+      - skip
+      - fail
+      - warning
+      - error
+  TestReport_Assert:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      result: optional<Testreport_assertResult>
+      message: optional<markdown>
+      detail: optional<string>
+  TestReport_Test:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      description: optional<string>
+      action: list<TestReport_Action1>
+  TestReport_Action1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: optional<TestReport_Operation>
+      assert: optional<TestReport_Assert>
+  TestReport_Teardown:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: list<TestReport_Action2>
+  TestReport_Action2:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: TestReport_Operation
+  TestscriptStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  TestScript:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<Identifier>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<TestscriptStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      origin: optional<list<TestScript_Origin>>
+      destination: optional<list<TestScript_Destination>>
+      metadata: optional<TestScript_Metadata>
+      fixture: optional<list<TestScript_Fixture>>
+      profile: optional<list<Reference>>
+      variable: optional<list<TestScript_Variable>>
+      setup: optional<TestScript_Setup>
+      test: optional<list<TestScript_Test>>
+      teardown: optional<TestScript_Teardown>
+  TestScript_Origin:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      index: optional<integer>
+      profile: Coding
+  TestScript_Destination:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      index: optional<integer>
+      profile: Coding
+  TestScript_Metadata:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      link: optional<list<TestScript_Link>>
+      capability: list<TestScript_Capability>
+  TestScript_Link:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      description: optional<string>
+  TestScript_Capability:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      required: optional<boolean>
+      validated: optional<boolean>
+      description: optional<string>
+      origin: optional<list<integer>>
+      destination: optional<integer>
+      link: optional<list<uri>>
+      capabilities: canonical
+  TestScript_Fixture:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      autocreate: optional<boolean>
+      autodelete: optional<boolean>
+      resource: optional<Reference>
+  TestScript_Variable:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      defaultValue: optional<string>
+      description: optional<string>
+      expression: optional<string>
+      headerField: optional<string>
+      hint: optional<string>
+      path: optional<string>
+      sourceId: optional<id>
+  TestScript_Setup:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: list<TestScript_Action>
+  TestScript_Action:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: optional<TestScript_Operation>
+      assert: optional<TestScript_Assert>
+  Testscript_operationMethod:
+    enum:
+      - delete
+      - get
+      - options
+      - patch
+      - post
+      - put
+      - head
+  TestScript_Operation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      type: optional<Coding>
+      resource: optional<code>
+      label: optional<string>
+      description: optional<string>
+      accept: optional<code>
+      contentType: optional<code>
+      destination: optional<integer>
+      encodeRequestUrl: optional<boolean>
+      method: optional<Testscript_operationMethod>
+      origin: optional<integer>
+      params: optional<string>
+      requestHeader: optional<list<TestScript_RequestHeader>>
+      requestId: optional<id>
+      responseId: optional<id>
+      sourceId: optional<id>
+      targetId: optional<id>
+      url: optional<string>
+  TestScript_RequestHeader:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      field: optional<string>
+      value: optional<string>
+  Testscript_assertDirection:
+    enum:
+      - response
+      - request
+  Testscript_assertOperator:
+    enum:
+      - equals
+      - notEquals
+      - in
+      - notIn
+      - greaterThan
+      - lessThan
+      - empty
+      - notEmpty
+      - contains
+      - notContains
+      - eval
+  Testscript_assertRequestmethod:
+    enum:
+      - delete
+      - get
+      - options
+      - patch
+      - post
+      - put
+      - head
+  Testscript_assertResponse:
+    enum:
+      - okay
+      - created
+      - noContent
+      - notModified
+      - bad
+      - forbidden
+      - notFound
+      - methodNotAllowed
+      - conflict
+      - gone
+      - preconditionFailed
+      - unprocessable
+  TestScript_Assert:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      label: optional<string>
+      description: optional<string>
+      direction: optional<Testscript_assertDirection>
+      compareToSourceId: optional<string>
+      compareToSourceExpression: optional<string>
+      compareToSourcePath: optional<string>
+      contentType: optional<code>
+      expression: optional<string>
+      headerField: optional<string>
+      minimumId: optional<string>
+      navigationLinks: optional<boolean>
+      operator: optional<Testscript_assertOperator>
+      path: optional<string>
+      requestMethod: optional<Testscript_assertRequestmethod>
+      requestURL: optional<string>
+      resource: optional<code>
+      response: optional<Testscript_assertResponse>
+      responseCode: optional<string>
+      sourceId: optional<id>
+      validateProfileId: optional<id>
+      value: optional<string>
+      warningOnly: optional<boolean>
+  TestScript_Test:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      description: optional<string>
+      action: list<TestScript_Action1>
+  TestScript_Action1:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: optional<TestScript_Operation>
+      assert: optional<TestScript_Assert>
+  TestScript_Teardown:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      action: list<TestScript_Action2>
+  TestScript_Action2:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      operation: TestScript_Operation
+  ValuesetStatus:
+    enum:
+      - draft
+      - active
+      - retired
+      - unknown
+  ValueSet:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      url: optional<uri>
+      identifier: optional<list<Identifier>>
+      version: optional<string>
+      name: optional<string>
+      title: optional<string>
+      status: optional<ValuesetStatus>
+      experimental: optional<boolean>
+      date: optional<dateTime>
+      publisher: optional<string>
+      contact: optional<list<ContactDetail>>
+      description: optional<markdown>
+      useContext: optional<list<UsageContext>>
+      jurisdiction: optional<list<CodeableConcept>>
+      immutable: optional<boolean>
+      purpose: optional<markdown>
+      copyright: optional<markdown>
+      compose: optional<ValueSet_Compose>
+      expansion: optional<ValueSet_Expansion>
+  ValueSet_Compose:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      lockedDate: optional<date>
+      inactive: optional<boolean>
+      include: list<ValueSet_Include>
+      exclude: optional<list<ValueSet_Include>>
+  ValueSet_Include:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      system: optional<uri>
+      version: optional<string>
+      concept: optional<list<ValueSet_Concept>>
+      filter: optional<list<ValueSet_Filter>>
+      valueSet: optional<list<canonical>>
+  ValueSet_Concept:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      code: optional<code>
+      display: optional<string>
+      designation: optional<list<ValueSet_Designation>>
+  ValueSet_Designation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      language: optional<code>
+      use: optional<Coding>
+      value: optional<string>
+  Valueset_filterOp:
+    enum:
+      # - "="
+      # - is-a
+      # - descendent-of
+      # - is-not-a
+      - regex
+      - in
+      # - not-in
+      - generalizes
+      - exists
+  ValueSet_Filter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      property: optional<code>
+      op: optional<Valueset_filterOp>
+      value: optional<string>
+  ValueSet_Expansion:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<uri>
+      timestamp: optional<dateTime>
+      total: optional<integer>
+      offset: optional<integer>
+      parameter: optional<list<ValueSet_Parameter>>
+      contains: optional<list<ValueSet_Contains>>
+  ValueSet_Parameter:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      name: optional<string>
+      valueString: optional<string>
+      valueBoolean: optional<boolean>
+      valueInteger: optional<double>
+      valueDecimal: optional<double>
+      valueUri: optional<string>
+      valueCode: optional<string>
+      valueDateTime: optional<string>
+  ValueSet_Contains:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      system: optional<uri>
+      abstract: optional<boolean>
+      inactive: optional<boolean>
+      version: optional<string>
+      code: optional<code>
+      display: optional<string>
+      designation: optional<list<ValueSet_Designation>>
+      contains: optional<list<ValueSet_Contains>>
+  VerificationResult:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      target: optional<list<Reference>>
+      targetLocation: optional<list<string>>
+      need: optional<CodeableConcept>
+      status: optional<code>
+      statusDate: optional<dateTime>
+      validationType: optional<CodeableConcept>
+      validationProcess: optional<list<CodeableConcept>>
+      frequency: optional<Timing>
+      lastPerformed: optional<dateTime>
+      nextScheduled: optional<date>
+      failureAction: optional<CodeableConcept>
+      primarySource: optional<list<VerificationResult_PrimarySource>>
+      attestation: optional<VerificationResult_Attestation>
+      validator: optional<list<VerificationResult_Validator>>
+  VerificationResult_PrimarySource:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      who: optional<Reference>
+      type: optional<list<CodeableConcept>>
+      communicationMethod: optional<list<CodeableConcept>>
+      validationStatus: optional<CodeableConcept>
+      validationDate: optional<dateTime>
+      canPushUpdates: optional<CodeableConcept>
+      pushTypeAvailable: optional<list<CodeableConcept>>
+  VerificationResult_Attestation:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      who: optional<Reference>
+      onBehalfOf: optional<Reference>
+      communicationMethod: optional<CodeableConcept>
+      date: optional<date>
+      sourceIdentityCertificate: optional<string>
+      proxyIdentityCertificate: optional<string>
+      proxySignature: optional<Signature>
+      sourceSignature: optional<Signature>
+  VerificationResult_Validator:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      organization: Reference
+      identityCertificate: optional<string>
+      attestationSignature: optional<Signature>
+  VisionPrescription:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      text: optional<Narrative>
+      contained: optional<list<ResourceList>>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      identifier: optional<list<Identifier>>
+      status: optional<code>
+      created: optional<dateTime>
+      patient: Reference
+      encounter: optional<Reference>
+      dateWritten: optional<dateTime>
+      prescriber: Reference
+      lensSpecification: list<VisionPrescription_LensSpecification>
+  Visionprescription_lensspecificationEye:
+    enum:
+      - right
+      - left
+  VisionPrescription_LensSpecification:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      product: CodeableConcept
+      eye: optional<Visionprescription_lensspecificationEye>
+      sphere: optional<decimal>
+      cylinder: optional<decimal>
+      axis: optional<integer>
+      prism: optional<list<VisionPrescription_Prism>>
+      add: optional<decimal>
+      power: optional<decimal>
+      backCurve: optional<decimal>
+      diameter: optional<decimal>
+      duration: optional<Quantity>
+      color: optional<string>
+      brand: optional<string>
+      note: optional<list<Annotation>>
+  Visionprescription_prismBase:
+    enum:
+      - up
+      - down
+      - in
+      - out
+  VisionPrescription_Prism:
+    fields:
+      id: optional<string>
+      extension: optional<list<Extension>>
+      modifierExtension: optional<list<Extension>>
+      amount: optional<decimal>
+      base: optional<Visionprescription_prismBase>
+  Project:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      name: string
+      description: optional<string>
+      owner: Reference
+      features: optional<list<code>>
+      defaultPatientAccessPolicy: optional<Reference>
+  ProjectMembership:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      project: Reference
+      user: Reference
+      profile: Reference
+      accessPolicy: optional<Reference>
+      userConfiguration: optional<Reference>
+      admin: optional<boolean>
+  ClientApplication:
+    fields:
+      resourceType: string
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      name: optional<string>
+      description: optional<string>
+      secret: string
+      redirectUri: optional<string>
+  User:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      email: string
+      passwordHash: string
+      admin: optional<boolean>
+  Login:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      client: optional<Reference>
+      user: optional<Reference>
+      membership: optional<Reference>
+      scope: optional<string>
+      authMethod: optional<string>
+      authTime: optional<instant>
+      cookie: optional<string>
+      code: optional<string>
+      codeChallenge: optional<string>
+      codeChallengeMethod: optional<string>
+      refreshSecret: optional<string>
+      nonce: optional<string>
+      granted: optional<boolean>
+      revoked: optional<boolean>
+      compartments: optional<list<Reference>>
+      admin: optional<boolean>
+      remoteAddress: optional<string>
+      userAgent: optional<string>
+  PasswordChangeRequest:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      user: optional<Reference>
+      secret: optional<string>
+      used: optional<boolean>
+      redirectUri: optional<string>
+  JsonWebKey:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      active: optional<boolean>
+      alg: optional<string>
+      kty: optional<string>
+      use: optional<string>
+      key_ops: optional<list<string>>
+      x5c: optional<list<string>>
+      "n": optional<string>
+      e: optional<string>
+      kid: optional<string>
+      x5t: optional<string>
+      d: optional<string>
+      p: optional<string>
+      q: optional<string>
+      dp: optional<string>
+      dq: optional<string>
+      qi: optional<string>
+  Bot:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      name: optional<string>
+      description: optional<string>
+      runtimeVersion: optional<string>
+      photo: optional<Attachment>
+      code: optional<string>
+      runAsUser: optional<boolean>
+  AccessPolicy:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      name: optional<string>
+      compartment: optional<Reference>
+      resource: optional<list<AccessPolicy_Resource>>
+  AccessPolicy_Resource:
+    fields:
+      resourceType: optional<string>
+      compartment: optional<Reference>
+      readonly: optional<boolean>
+      hiddenFields: optional<list<string>>
+      readonlyFields: optional<list<string>>
+  UserConfiguration:
+    fields:
+      resourceType: optional<string>
+      id: optional<id>
+      meta: optional<Meta>
+      implicitRules: optional<uri>
+      language: optional<code>
+      name: optional<string>
+      menu: optional<list<UserConfiguration_Menu>>
+      search: optional<list<UserConfiguration_Search>>
+      option: optional<list<UserConfiguration_Option>>
+  UserConfiguration_Menu:
+    fields:
+      title: optional<string>
+      link: optional<list<UserConfiguration_Menu_Link>>
+  UserConfiguration_Menu_Link:
+    fields:
+      name: optional<string>
+      target: optional<string>
+  UserConfiguration_Search:
+    fields:
+      name: optional<string>
+      criteria: optional<string>
+  UserConfiguration_Option:
+    fields:
+      id: optional<id>
+      valueBoolean: optional<boolean>
+      valueCode: optional<string>
+      valueDecimal: optional<double>
+      valueInteger: optional<double>
+      valueString: optional<string>
+services:
+  http:
+    FhirService:
+      endpoints:
+        search:
+          method: GET
+          path: /fhir/R4/{resourceType}
+          parameters:
+            resourceType: string
+          docs: Search
+          response: Bundle
+          errors: []
+        createResource:
+          method: POST
+          path: /fhir/R4/{resourceType}
+          parameters:
+            resourceType: string
+          docs: Create Resource
+          response: ResourceList
+          request: ResourceList
+          errors: []
+        readResource:
+          method: GET
+          path: /fhir/R4/{resourceType}/{id}
+          parameters:
+            resourceType: string
+            id: string
+          docs: Read Resource
+          response: ResourceList
+          errors: []
+        updateResource:
+          method: PUT
+          path: /fhir/R4/{resourceType}/{id}
+          parameters:
+            resourceType: string
+            id: string
+          docs: Update Resource
+          response: ResourceList
+          request: ResourceList
+          errors: []
+        deleteResource:
+          method: DELETE
+          path: /fhir/R4/{resourceType}/{id}
+          parameters:
+            resourceType: string
+            id: string
+          docs: Delete Resource
+          errors: []
+        readResourceHistory:
+          method: GET
+          path: /fhir/R4/{resourceType}/{id}/_history
+          parameters:
+            resourceType: string
+            id: string
+          docs: Read Resource History
+          response: Bundle
+          errors: []
+        readVersion:
+          method: GET
+          path: /fhir/R4/{resourceType}/{id}/_history/{versionId}
+          parameters:
+            resourceType: string
+            id: string
+            versionId: string
+          docs: Read Version
+          response: ResourceList
+          errors: []


### PR DESCRIPTION
Adds FHIR API Definition


Issues for improvements to API protocol: 
- API definition doesn't have native support for UUIDs which are just modeled as strings: https://github.com/fern-api/fern/issues/51)
- API definition doesn't support validation for primitive aliases (i.e. positiveInt is just an integer, date is a string: https://github.com/fern-api/fern/issues/67
- Enums with values that are not alphabetic should be supported: https://github.com/fern-api/fern/issues/62